### PR TITLE
relax version requirements for `datasets` python package

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,6 +57,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-          JULIA_CONDAPKG_OPENSSL_VERSION: "ignore"
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Manifest.toml
 .CondaPkg
 .vscode
 .ipynb_checkpoints
+LocalPreferences.toml

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,5 +1,7 @@
+channels = ["conda-forge"]
+
 [deps]
-datasets = ">=3.0, <4"
-numpy = ">=2.0, <3"
+datasets = ">=2.0, <4"
+numpy = ""
 pillow = ""
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,13 @@
 name = "HuggingFaceDatasets"
 uuid = "d94b9a45-fdf5-4270-b024-5cbb9ef7117d"
 authors = ["Carlo Lucibello"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 DLPack = "53c2dc0f-f7d5-43fd-8906-6c0220547083"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
-Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [compat]
@@ -16,7 +15,6 @@ CondaPkg = "0.2"
 DLPack = "0.3"
 ImageCore = "0.9, 0.10"
 MLUtils = "0.4.1"
-Preferences = "1.4.3"
 PythonCall = "0.9"
 julia = "1.9"
 

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 DLPack = "53c2dc0f-f7d5-43fd-8906-6c0220547083"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [compat]
@@ -15,6 +16,7 @@ CondaPkg = "0.2"
 DLPack = "0.3"
 ImageCore = "0.9, 0.10"
 MLUtils = "0.4.1"
+Preferences = "1.4.3"
 PythonCall = "0.9"
 julia = "1.9"
 

--- a/src/HuggingFaceDatasets.jl
+++ b/src/HuggingFaceDatasets.jl
@@ -37,7 +37,6 @@ include("load_dataset.jl")
 export load_dataset
 
 function __init__()
-    ENV["JULIA_CONDAPKG_OPENSSL_VERSION"] = "ignore"
     # Since it is illegal in PythonCall to import a python module in a module, we need to do this here.
     # https://juliapy.github.io/PythonCall.jl/dev/pythoncall-reference/#PythonCall.Core.pycopy!
     PythonCall.pycopy!(datasets, pyimport("datasets"))


### PR DESCRIPTION
Unfortunately the latest versions of `datasets` require a version of SSL above the one used in julia, and we incur in the issues highlighted in 
https://github.com/JuliaPy/PythonCall.jl/issues/571

Therefore, I relax here the bounds on `datasets`, which means in practice that we will get an old version until julia won't update its dependence.