### PR TITLE
Implement deepcopy via deepcopy_internal; use shallow copy internally

### DIFF
--- a/src/HuggingFaceDatasets.jl
+++ b/src/HuggingFaceDatasets.jl
@@ -9,7 +9,7 @@ using ImageCore
 const datasets = PythonCall.pynew()
 const PIL = PythonCall.pynew()
 const np = PythonCall.pynew()
-const copy = PythonCall.pynew()
+const pycopy = PythonCall.pynew() # the python `copy` module (renamed to avoid shadowing `Base.copy`)
 
 export datasets
 
@@ -44,7 +44,7 @@ function __init__()
     pyimport("PIL.PngImagePlugin")
     pyimport("PIL.JpegImagePlugin")
     PythonCall.pycopy!(np, pyimport("numpy"))
-    PythonCall.pycopy!(copy, pyimport("copy"))
+    PythonCall.pycopy!(pycopy, pyimport("copy"))
 end
 
 end # module

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -63,7 +63,7 @@ end
 
 function Base.deepcopy_internal(ds::Dataset, stackdict::IdDict)
     haskey(stackdict, ds) && return stackdict[ds]::Dataset
-    pyds = copy.deepcopy(getfield(ds, :pyds))
+    pyds = pycopy.deepcopy(getfield(ds, :pyds))
     jltransform = Base.deepcopy_internal(getfield(ds, :jltransform), stackdict)
     ds2 = Dataset(pyds, jltransform)
     stackdict[ds] = ds2
@@ -74,7 +74,7 @@ end
 # but has an independent format, so `set_format!`/`set_jltransform!` on the copy
 # do not affect the original. Used internally by the copy-on-write helpers.
 function Base.copy(ds::Dataset)
-    pyds = copy.copy(getfield(ds, :pyds))
+    pyds = pycopy.copy(getfield(ds, :pyds))
     return Dataset(pyds, getfield(ds, :jltransform))
 end
 
@@ -107,7 +107,7 @@ Dict{String, Any} with 2 entries:
 ```
 """
 function with_format(ds::Dataset, format::AbstractString)
-    ds = Base.copy(ds)
+    ds = copy(ds)
     return set_format!(ds, format)
 end
 
@@ -154,7 +154,7 @@ If `transform` is `nothing` or `identity`, the returned dataset will not be tran
 See also [`set_jltransform!`](@ref) for the mutating version.
 """
 function with_jltransform(ds::Dataset, transform)
-    ds = Base.copy(ds)
+    ds = copy(ds)
     return set_jltransform!(ds, transform)
 end
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -61,9 +61,21 @@ function Base.getindex(ds::Dataset, i::AbstractString)
     return ds.jltransform(d)[i]
 end
 
-function Base.deepcopy(ds::Dataset)
-    pyds = copy.deepcopy(ds.pyds)
-    return Dataset(pyds, ds.jltransform)
+function Base.deepcopy_internal(ds::Dataset, stackdict::IdDict)
+    haskey(stackdict, ds) && return stackdict[ds]::Dataset
+    pyds = copy.deepcopy(getfield(ds, :pyds))
+    jltransform = Base.deepcopy_internal(getfield(ds, :jltransform), stackdict)
+    ds2 = Dataset(pyds, jltransform)
+    stackdict[ds] = ds2
+    return ds2
+end
+
+# Shallow copy: the returned dataset shares the underlying Arrow data with `ds`
+# but has an independent format, so `set_format!`/`set_jltransform!` on the copy
+# do not affect the original. Used internally by the copy-on-write helpers.
+function Base.copy(ds::Dataset)
+    pyds = copy.copy(getfield(ds, :pyds))
+    return Dataset(pyds, getfield(ds, :jltransform))
 end
 
 Base.show(io::IO, ds::Dataset) = print(io, ds.pyds)
@@ -95,7 +107,7 @@ Dict{String, Any} with 2 entries:
 ```
 """
 function with_format(ds::Dataset, format::AbstractString)
-    ds = deepcopy(ds)
+    ds = Base.copy(ds)
     return set_format!(ds, format)
 end
 
@@ -142,7 +154,7 @@ If `transform` is `nothing` or `identity`, the returned dataset will not be tran
 See also [`set_jltransform!`](@ref) for the mutating version.
 """
 function with_jltransform(ds::Dataset, transform)
-    ds = deepcopy(ds)
+    ds = Base.copy(ds)
     return set_jltransform!(ds, transform)
 end
 

--- a/src/datasetdict.jl
+++ b/src/datasetdict.jl
@@ -44,7 +44,7 @@ end
 
 function Base.deepcopy_internal(d::DatasetDict, stackdict::IdDict)
     haskey(stackdict, d) && return stackdict[d]::DatasetDict
-    pyd = copy.deepcopy(getfield(d, :pyd))
+    pyd = pycopy.deepcopy(getfield(d, :pyd))
     jltransform = Base.deepcopy_internal(getfield(d, :jltransform), stackdict)
     d2 = DatasetDict(pyd, jltransform)
     stackdict[d] = d2
@@ -55,7 +55,7 @@ end
 # but has an independent format, so `set_format!`/`set_jltransform!` on the copy
 # do not affect the original. Used internally by the copy-on-write helpers.
 function Base.copy(d::DatasetDict)
-    pyd = copy.copy(getfield(d, :pyd))
+    pyd = pycopy.copy(getfield(d, :pyd))
     return DatasetDict(pyd, getfield(d, :jltransform))
 end
 
@@ -68,7 +68,7 @@ Base.show(io::IO, ds::DatasetDict) = print(io, ds.pyd)
 Return a copy of `d` with the julia `transform` applied to each [`Dataset`](@ref).
 """
 function with_jltransform(d::DatasetDict, transform)
-    d = Base.copy(d)
+    d = copy(d)
     set_jltransform!(d, transform)
     return d
 end
@@ -102,7 +102,7 @@ with [`py2jl`](@ref) and copyless conversion from python types
 will be used when possible.
 """
 function with_format(d::DatasetDict, format)
-    d = Base.copy(d)
+    d = copy(d)
     return set_format!(d, format)
 end
 

--- a/src/datasetdict.jl
+++ b/src/datasetdict.jl
@@ -42,9 +42,21 @@ function Base.getindex(d::DatasetDict, i::AbstractString)
     return Dataset(x, d.jltransform)
 end
 
-function Base.deepcopy(d::DatasetDict)
-    pyd = copy.deepcopy(d.pyd)
-    return DatasetDict(pyd, d.jltransform)
+function Base.deepcopy_internal(d::DatasetDict, stackdict::IdDict)
+    haskey(stackdict, d) && return stackdict[d]::DatasetDict
+    pyd = copy.deepcopy(getfield(d, :pyd))
+    jltransform = Base.deepcopy_internal(getfield(d, :jltransform), stackdict)
+    d2 = DatasetDict(pyd, jltransform)
+    stackdict[d] = d2
+    return d2
+end
+
+# Shallow copy: the returned dict shares the underlying Arrow data with `d`
+# but has an independent format, so `set_format!`/`set_jltransform!` on the copy
+# do not affect the original. Used internally by the copy-on-write helpers.
+function Base.copy(d::DatasetDict)
+    pyd = copy.copy(getfield(d, :pyd))
+    return DatasetDict(pyd, getfield(d, :jltransform))
 end
 
 Base.show(io::IO, ds::DatasetDict) = print(io, ds.pyd)
@@ -56,7 +68,7 @@ Base.show(io::IO, ds::DatasetDict) = print(io, ds.pyd)
 Return a copy of `d` with the julia `transform` applied to each [`Dataset`](@ref).
 """
 function with_jltransform(d::DatasetDict, transform)
-    d = deepcopy(d)
+    d = Base.copy(d)
     set_jltransform!(d, transform)
     return d
 end
@@ -90,7 +102,7 @@ with [`py2jl`](@ref) and copyless conversion from python types
 will be used when possible.
 """
 function with_format(d::DatasetDict, format)
-    d = deepcopy(d)
+    d = Base.copy(d)
     return set_format!(d, format)
 end
 


### PR DESCRIPTION
Closes #11.

## Problem

`Base.deepcopy` was overridden directly for `Dataset`/`DatasetDict`. That's the wrong extension point: Julia's deepcopy recursion dispatches on `deepcopy_internal(x, ::IdDict)`, not `deepcopy`. As a result the override only fired for a top-level `deepcopy(ds)` and was bypassed whenever a dataset was nested inside another object being deep-copied — the inner `Py` field then fell to the default `deepcopy`, which copies the pointer and leaves the "copy" aliasing the *same* underlying Python object (mutations leak across).

## Changes

- **Override `Base.deepcopy_internal`** for `Dataset` and `DatasetDict`, tracking copies in the `IdDict` so recursion works when datasets are nested and shared references stay shared (aliasing preserved).
- **Add shallow `Base.copy` methods** (via Python's `copy.copy`): the returned object shares the underlying Arrow data but has an independent format/transform.
- **Copy-on-write helpers use the shallow copy**: `with_format` and `with_jltransform` (both `Dataset` and `DatasetDict`) now call `copy` instead of `deepcopy`, so flipping a format flag no longer duplicates the entire dataset — only the format metadata is isolated.
- **Rename the internal Python `copy` module binding to `pycopy`**: it previously shadowed `Base.copy` inside the module. Renaming it un-shadows `Base.copy` so the new methods can be called as a plain `copy(ds)` internally, instead of a qualified `Base.copy(ds)` workaround.

## Verification

- `with_format`/`copy` isolate format & transform changes — the original is untouched and the data is shared.
- Nested `deepcopy` now returns genuinely independent datasets with aliasing preserved.
- Full test suite passes locally: `dataset` 62/62, `datasetdict` 24/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)