### PR TITLE
Grant write permission to docs deploy job

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -13,6 +13,10 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+      statuses: write
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3


### PR DESCRIPTION
Fix #28 

## Problem

The docs CI on `main` fails at the **deploy** step (build succeeds):

```
remote: Permission to JuliaGenAI/HuggingFaceDatasets.jl.git denied to github-actions[bot].
fatal: ... error: 403
```

`DOCUMENTER_KEY` is unset, so Documenter deploys via `GITHUB_TOKEN`. The `docs` job had no `permissions` block, and the org's default token permission is read-only — so the bot can't push to `gh-pages`.

## Fix

Grant the job `contents: write` (needed for the `gh-pages` push), plus `pull-requests: read` / `statuses: write` for preview deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)