### PR TITLE
Make DatasetDict an AbstractDict

### DIFF
--- a/src/datasetdict.jl
+++ b/src/datasetdict.jl
@@ -10,7 +10,7 @@ converts python types to julia types.
 
 See also [`load_dataset`](@ref) and [`Dataset`](@ref).
 """
-mutable struct DatasetDict
+mutable struct DatasetDict <: AbstractDict{String, Dataset}
     pyd::Py
     jltransform
 
@@ -41,6 +41,18 @@ function Base.getindex(d::DatasetDict, i::AbstractString)
     x = d.pyd[i]
     return Dataset(x, d.jltransform)
 end
+
+Base.keys(d::DatasetDict) = String[pyconvert(String, k) for k in d.pyd.keys()]
+
+Base.values(d::DatasetDict) = Dataset[d[k] for k in keys(d)]
+
+Base.pairs(d::DatasetDict) = Pair{String,Dataset}[k => d[k] for k in keys(d)]
+
+Base.haskey(d::DatasetDict, k::AbstractString) = pyconvert(Bool, pyin(k, d.pyd))
+
+Base.iterate(d::DatasetDict, state...) = iterate(pairs(d), state...)
+
+Base.get(d::DatasetDict, k::AbstractString, default) = haskey(d, k) ? d[k] : default
 
 function Base.deepcopy_internal(d::DatasetDict, stackdict::IdDict)
     haskey(stackdict, d) && return stackdict[d]::DatasetDict

--- a/test/datasetdict.jl
+++ b/test/datasetdict.jl
@@ -4,6 +4,24 @@ mnist = load_dataset("ylecun/mnist")
 @test mnist isa DatasetDict
 @test length(mnist) == 2
 
+@testset "dictionary interface" begin
+    @test DatasetDict <: AbstractDict{String, Dataset}
+    @test eltype(mnist) == Pair{String, Dataset}
+    @test keytype(mnist) == String
+    @test valtype(mnist) == Dataset
+    @test Set(keys(mnist)) == Set(["train", "test"])
+    @test keys(mnist) isa Vector{String}
+    @test all(v -> v isa Dataset, values(mnist))
+    @test length(values(mnist)) == 2
+    @test Set(first.(pairs(mnist))) == Set(["train", "test"])
+    @test all(p -> p.second isa Dataset, pairs(mnist))
+    @test haskey(mnist, "train")
+    @test !haskey(mnist, "nonexistent")
+    @test get(mnist, "train", nothing) isa Dataset
+    @test get(mnist, "nonexistent", nothing) === nothing
+    @test Set(k for (k, v) in mnist) == Set(["train", "test"])
+end
+
 @testset "indexing, no (jl)transform by default" begin
     @test_throws MethodError mnist[1]
     @test mnist["test"] isa Dataset


### PR DESCRIPTION
Closes #31.

Makes `DatasetDict` a subtype of `AbstractDict{String, Dataset}` and adds the dictionary interface, so splits can be accessed idiomatically:

```julia
dd = load_dataset("ylecun/mnist")
keys(dd)              # ["train", "test"]  — was [k for k in dd.keys()]
values(dd)            # Vector{Dataset}
pairs(dd)             # Vector{Pair{String,Dataset}}
haskey(dd, "train")   # true
get(dd, "x", nothing) # nothing
for (split, ds) in dd # iteration yields key => value pairs
    ...
end
```

## Details

- `mutable struct DatasetDict <: AbstractDict{String, Dataset}`.
- Explicit `keys`, `values`, `pairs`, `haskey`, `get`, `iterate`, `length`, `getindex`. `keys`/`values`/`pairs` return concrete `Vector`s.
- By subtyping `AbstractDict`, generic machinery derives for free: `Dict(dd)`, `collect`, `filter`, `merge`, comprehensions, and correct `eltype`/`keytype`/`valtype`.
- The custom `show` (Python repr) is preserved as it's more specific than the `AbstractDict` fallback.

The interface follows Julia's `AbstractDict` conventions rather than mirroring Python's `dict` names literally (`pairs` ↔ Python `items`; iteration yields pairs, not keys).

## Tests

Added a `dictionary interface` testset to `test/datasetdict.jl`; full file passes (39/39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)