### PR TITLE
Fix method-forwarding kwargs and jl2numpy; interface fixes + changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,20 @@ using Pkg; Pkg.test()
   `no_ci.jl` (larger downloads: cifar10, beans, cppe-5) **only when `CI` is
   not `"true"`**. Set `ENV["CI"]="true"` to mimic CI and skip those.
 - The first run downloads datasets and provisions the conda env, so it is slow.
+
+## Changelog
+
+Keep [`CHANGELOG.md`](CHANGELOG.md) up to date. It follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project uses
+[Semantic Versioning](https://semver.org/).
+
+- Any user-visible change (bug fix; added, changed, deprecated, or removed method or
+  behavior) must add a bullet under the `## [Unreleased]` heading, in the matching
+  category: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, or `Security`.
+  Purely internal changes (refactors, tests, CI, doc typos) don't need an entry.
+- Write entries for users, in the present tense, describing the effect rather than the
+  code change.
+- On release: rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`, add a fresh empty
+  `## [Unreleased]` above it, bump `version` in `Project.toml` per SemVer (new feature
+  → minor, bug fix → patch; for `0.x`, breaking → minor), and update the compare links
+  at the bottom of the file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `Base.firstindex`/`Base.lastindex` for `Dataset`, so `ds[begin]` and `ds[end]` work.
+- `Base.iterate` for `Dataset`; it iterates over observations, enabling
+  `for obs in ds`, `collect(ds)`, and comprehensions.
+- `reset_format!(::DatasetDict)` and a single-argument `set_format!(::DatasetDict)`,
+  mirroring the `Dataset` methods.
+
+### Changed
+- `py2jl` now converts any `PIL.Image.Image` (BMP/GIF/TIFF/WebP and images produced by
+  transforms), not only PNG/JPEG. Image modes other than RGB and grayscale (e.g. RGBA,
+  CMYK, palette) return the raw array instead of raising an error.
+- Invalid arguments now raise `ArgumentError`, and out-of-range indices raise
+  `BoundsError`, instead of `AssertionError`.
+
+### Fixed
+- Keyword arguments are correctly forwarded to wrapped Python methods (e.g.
+  `ds.train_test_split(test_size=0.2)`, `ds.shuffle(seed=…)`, `ds.map(batched=true)`).
+  They were previously passed as positional arguments and rejected by Python.
+- `jl2numpy` works again with numpy ≥ 2.1, which had broken the DLPack export path. It
+  now shares memory through the buffer protocol; the returned numpy array is writable,
+  and mutations propagate in both directions.
+
+## [0.3.4]
+
+Baseline. Changes up to and including this release are recorded in the
+[git history](https://github.com/JuliaGenAI/HuggingFaceDatasets.jl/commits/main) and the
+[GitHub releases](https://github.com/JuliaGenAI/HuggingFaceDatasets.jl/releases).
+
+[Unreleased]: https://github.com/JuliaGenAI/HuggingFaceDatasets.jl/compare/v0.3.4...HEAD
+[0.3.4]: https://github.com/JuliaGenAI/HuggingFaceDatasets.jl/releases/tag/v0.3.4

--- a/examples/flux_mnist.jl
+++ b/examples/flux_mnist.jl
@@ -33,8 +33,8 @@ function train(epochs)
     nhidden = 100
     device = cpu
 
-    train_data = load_dataset("mnist", split="train").with_format("julia")
-    test_data = load_dataset("mnist", split="test").with_format("julia")
+    train_data = load_dataset("ylecun/mnist", split="train").with_format("julia")
+    test_data = load_dataset("ylecun/mnist", split="test").with_format("julia")
     train_data = mapobs(mnist_transform, train_data)[:] # lazy apply transform then materialize
     test_data = mapobs(mnist_transform, test_data)[:]
     

--- a/perf/perf.jl
+++ b/perf/perf.jl
@@ -18,7 +18,7 @@ end
 
 function bench()
     mld = MNIST(split=:test)
-    ds_plain = load_dataset("mnist", split="test")
+    ds_plain = load_dataset("ylecun/mnist", split="test")
     ds_julia = with_format(ds_plain, "julia")
     ds_numpy = with_format(ds_plain, "numpy")
     ds_jnumpy = with_jltransform(py2jl, ds_numpy) # numpy + py2jl

--- a/src/HuggingFaceDatasets.jl
+++ b/src/HuggingFaceDatasets.jl
@@ -41,6 +41,7 @@ function __init__()
     # https://juliapy.github.io/PythonCall.jl/dev/pythoncall-reference/#PythonCall.Core.pycopy!
     PythonCall.pycopy!(datasets, pyimport("datasets"))
     PythonCall.pycopy!(PIL, pyimport("PIL"))
+    pyimport("PIL.Image")
     pyimport("PIL.PngImagePlugin")
     pyimport("PIL.JpegImagePlugin")
     PythonCall.pycopy!(np, pyimport("numpy"))

--- a/src/callable.jl
+++ b/src/callable.jl
@@ -3,6 +3,6 @@ struct CallableWrapper
 end
 
 function (cw::CallableWrapper)(args...; kwargs...)
-    y = cw.f(args..., kwargs...)
+    y = cw.f(args...; kwargs...)
     return py2jl(y)
 end

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -14,7 +14,9 @@ mutable struct Dataset
     jltransform
 
     function Dataset(pyds::Py, jltransform = identity)
-        @assert pyisinstance(pyds, datasets.Dataset)
+        if !pyisinstance(pyds, datasets.Dataset)
+            throw(ArgumentError("expected a `datasets.Dataset`, got $(pytype(pyds))"))
+        end
         return new(pyds, jltransform)
     end
 end
@@ -42,10 +44,20 @@ end
 
 Base.length(ds::Dataset) = length(ds.pyds)
 
+Base.firstindex(ds::Dataset) = 1
+Base.lastindex(ds::Dataset) = length(ds)
+
+# Iterate over observations, so that `for obs in ds`, `collect(ds)`, etc. work.
+function Base.iterate(ds::Dataset, state=(1, length(ds)))
+    i, n = state
+    i > n && return nothing
+    return ds[i], (i + 1, n)
+end
+
 Base.getindex(ds::Dataset, ::Colon) = ds[1:length(ds)]
 
 function Base.getindex(ds::Dataset, i::AbstractVector{<:Integer})
-    @assert all(>(0), i)
+    all(≥(1), i) || throw(BoundsError(ds, i))
     x = getfield(ds, :pyds)[i .- 1]
     return ds.jltransform(x)
 end

--- a/src/datasetdict.jl
+++ b/src/datasetdict.jl
@@ -1,10 +1,10 @@
 """
-    DatasetDict(pydatasetdict::Py; transform = identity)
+    DatasetDict(pyd::Py, jltransform = identity)
 
-A `DatasetDict` is a dictionary of `Dataset`s. 
+A `DatasetDict` is a dictionary of `Dataset`s.
 It is a wrapper around a `datasets.DatasetDict` object.
 
-The `transform` is applied to each [`Dataset`](@ref). 
+The `jltransform` is applied to each [`Dataset`](@ref).
 The [`py2jl`](@ref) transform provided by this package
 converts python types to julia types.
 
@@ -15,7 +15,9 @@ mutable struct DatasetDict <: AbstractDict{String, Dataset}
     jltransform
 
     function DatasetDict(pydatasetdict::Py, jltransform = identity)
-        @assert pyisinstance(pydatasetdict, datasets.DatasetDict)
+        if !pyisinstance(pydatasetdict, datasets.DatasetDict)
+            throw(ArgumentError("expected a `datasets.DatasetDict`, got $(pytype(pydatasetdict))"))
+        end
         return new(pydatasetdict, jltransform)
     end
 end
@@ -73,7 +75,7 @@ end
 
 Base.show(io::IO, ds::DatasetDict) = print(io, ds.pyd)
 
-""""
+"""
     with_jltransform(d::DatasetDict, transform)
     with_jltransform(transform, d::DatasetDict)
 
@@ -132,5 +134,18 @@ function set_format!(d::DatasetDict, format)
         d.pyd.set_format(format)
         d.jltransform = identity
     end
+    return d
+end
+
+set_format!(d::DatasetDict) = reset_format!(d)
+
+"""
+    reset_format!(d::DatasetDict)
+
+Reset the format of `d`, removing any python format and julia transform.
+"""
+function reset_format!(d::DatasetDict)
+    d.pyd.set_format(nothing)
+    d.jltransform = identity
     return d
 end

--- a/src/observation.jl
+++ b/src/observation.jl
@@ -8,6 +8,6 @@ function MLUtils.getobs(py::Py, i::Integer)
     elseif pyisinstance(py, np.ndarray)
         return py[i-1]
     else
-        return error("Py type $(pytype(py)) non supported yet")
+        return error("Py type $(pytype(py)) not supported yet")
     end
 end

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -26,15 +26,16 @@ function py2jl(x::Py)
     # handle numpy arrays   
     elseif pyisinstance(x, np.ndarray)
         return numpy2jl(x)
-    # handle PIL images
-    elseif pyisinstance(x, PIL.PngImagePlugin.PngImageFile) || pyisinstance(x, PIL.JpegImagePlugin.JpegImageFile)
+    # handle PIL images (any subclass: PNG/JPEG/BMP/GIF/TIFF/... and transform outputs)
+    elseif pyisinstance(x, PIL.Image.Image)
         a = numpy2jl(np.array(x))
         if ndims(a) == 3 && size(a, 1) == 3
             return colorview(RGB{N0f8}, a)
         elseif ndims(a) == 2
             return reinterpret(Gray{N0f8}, a)
         else
-            error("Unknown image format")
+            # other modes (e.g. RGBA, CMYK, palette): return the raw (permuted) array
+            return a
         end
     # handle other types
     else
@@ -60,12 +61,19 @@ end
 """
     jl2numpy(x)
 
-Convert a Julia array to a numpy array using DLPack.jl.
-The conversion is copyless, and mutations to the numpy array are reflected in the Julia array.
-The returned numpy array has permuted dimensions with respect to the input Julia array.
+Convert a Julia array to a numpy array, sharing memory via the buffer protocol.
+The conversion is copyless, and mutations to the numpy array are reflected in the
+Julia array (and vice versa). The returned numpy array has permuted dimensions with
+respect to the input Julia array, since numpy is row-major and Julia is column-major.
 
 See also [`numpy2jl`](@ref).
 """
 function jl2numpy(x::AbstractArray)
-    return DLPack.share(x, np.from_dlpack)
+    # `np.asarray(Py(x))` exposes `x`'s memory to numpy through the buffer protocol
+    # without copying, yielding a writable view with the same shape but column-major
+    # (F-contiguous) strides. `.T` reverses the axes so the result matches the
+    # dimension permutation of `numpy2jl`, i.e. `numpy2jl(jl2numpy(x)) == x`.
+    # (We avoid `np.from_dlpack` here: numpy >= 2.1 imports DLPack buffers as
+    # read-only, which would break the documented write-back behaviour.)
+    return np.asarray(Py(x)).T
 end

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -18,8 +18,28 @@ end
     @test mnist.format["type"] === nothing
 end
 
+@testset "firstindex / lastindex / iteration" begin
+    ds = Dataset(HuggingFaceDatasets.datasets.Dataset.from_dict(
+        pydict(Dict("x" => pylist([10, 20, 30])))))
+    @test firstindex(ds) == 1
+    @test lastindex(ds) == 3
+    @test pyconvert(Int, ds[end]["x"]) == 30
+    @test pyconvert(Int, ds[begin]["x"]) == 10
+    @test [pyconvert(Int, o["x"]) for o in ds] == [10, 20, 30]   # iterates observations
+    @test length(collect(ds)) == 3
+end
+
+@testset "keyword arguments are forwarded to python methods" begin
+    # `train_test_split` requires the `test_size` keyword: regression test for the
+    # kwargs-forwarding bug where keywords were splatted as positional arguments.
+    split = mnist.train_test_split(test_size=0.2)
+    @test split isa DatasetDict
+    @test Set(keys(split)) == Set(["train", "test"])
+    @test length(split["train"]) + length(split["test"]) == length(mnist)
+end
+
 @testset "indexing, no (jl)transform by default" begin
-    @test_throws AssertionError mnist[0]
+    @test_throws BoundsError mnist[0]
     @test length(mnist[:]["label"]) == 10000
 
     x = mnist[1]

--- a/test/datasetdict.jl
+++ b/test/datasetdict.jl
@@ -70,6 +70,18 @@ end
     @test d["test"].format["type"] === nothing
 end
 
+@testset "reset_format! / set_format! (DatasetDict)" begin
+    d = with_format(mnist, "julia")
+    @test d["test"][1] isa Dict                              # julia format active
+    reset_format!(d)
+    @test pyisinstance(d["test"][1], pytype(pydict()))       # back to raw python
+    set_format!(d, "numpy")
+    @test d["test"].format["type"] == "numpy"
+    set_format!(d)                                           # single-arg form resets
+    @test d["test"].format["type"] === nothing
+    @test mnist["test"].format["type"] === nothing          # original untouched
+end
+
 @testset "set_jltransform!" begin
     d = deepcopy(mnist)
     set_jltransform!(d) do x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,10 @@ using HuggingFaceDatasets, PythonCall, ImageCore
 PIL = HuggingFaceDatasets.PIL
 np = HuggingFaceDatasets.np
 
+@testset "transforms" begin
+    include("transforms.jl")
+end
+
 @testset "dataset" begin
     include("dataset.jl")
 end

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -6,6 +6,23 @@
     @test py2jl(d) isa Dict{String,Int}
 end
 
+@testset "jl2numpy / numpy2jl" begin
+    # round-trip across dtypes and dimensionalities (dims are permuted then permuted back)
+    for x in Any[Float32[1 2; 3 4], Int64[1, 2, 3, 4], rand(UInt8, 2, 3, 4)]
+        y = jl2numpy(x)
+        @test size(numpy2jl(y)) == size(x)
+        @test numpy2jl(y) == x
+    end
+
+    # the numpy view shares memory with the Julia array in both directions
+    x = [1.0 2.0; 3.0 4.0]
+    y = jl2numpy(x)
+    x[1, 1] = 99.0
+    @test pyconvert(Float64, y[0, 0]) == 99.0   # julia -> numpy
+    y[0, 0] = 7.0
+    @test x[1, 1] == 7.0                         # numpy -> julia (writable)
+end
+
 # only if no CI
 # if isempty(ENV["CI"])
 #     @testset "py2jl" begin


### PR DESCRIPTION
## Summary

Addresses findings from a repository review. Fixes two bugs that made exported
functionality non-functional, tightens the interface, and establishes a changelog.
All changes were verified at runtime against `datasets` 3.6.0 / numpy 2.5.0.

## Bug fixes

- **Keyword-argument forwarding.** `CallableWrapper` splatted keyword arguments
  positionally (`cw.f(args..., kwargs...)`), so every wrapped Python method that
  takes keywords failed — e.g. `ds.train_test_split(test_size=0.2)` raised
  `ValueError: Invalid value for test_size: (Julia: :test_size, 0.25) of type <class 'tuple'>`.
  This affected `map(batched=…)`, `filter`, `sort`, `shuffle(seed=…)`, `select`,
  `cast_column`, `rename_column`, etc. Fixed to `cw.f(args...; kwargs...)`.

- **`jl2numpy` on numpy ≥ 2.1.** The DLPack export path threw
  (`AttributeError: 'PyCapsule' object has no attribute '__dlpack__'` /
  `MethodError … copy, max_version, dl_device`) because numpy 2.1+ uses the DLPack
  v1.0 protocol that DLPack.jl 0.3's callback doesn't support. Reimplemented via the
  buffer protocol (`np.asarray(Py(x)).T`): a **writable**, zero-copy, GC-safe view
  that preserves the documented dimension permutation, so `numpy2jl(jl2numpy(x)) == x`
  (verified across `Float32`/`Int64`/`UInt8`, 1–3D). `numpy2jl` is unchanged and still
  uses DLPack.

## Interface improvements

- `firstindex`/`lastindex`/`iterate` for `Dataset` — `ds[begin]`, `ds[end]`,
  `for obs in ds`, and `collect(ds)` now work.
- `reset_format!(::DatasetDict)` and a single-argument `set_format!(::DatasetDict)`,
  mirroring `Dataset`.
- `py2jl` now converts any `PIL.Image.Image` (BMP/GIF/TIFF/WebP and transform
  outputs), not just PNG/JPEG; non-RGB/Gray modes (RGBA, CMYK, palette) return the raw
  array instead of raising `error("Unknown image format")`.
- Invalid arguments raise `ArgumentError` and out-of-range indices raise `BoundsError`
  instead of `AssertionError`.

## Docs, tests, changelog

- Fixed the `DatasetDict` docstring signature, a `""""` typo, and an error-message typo;
  updated the examples to `ylecun/mnist`.
- Wired the previously-orphaned `test/transforms.jl` into the runner and added
  regression tests for kwargs forwarding, `jl2numpy`/`numpy2jl`, `Dataset`
  indexing/iteration, and `DatasetDict` formats.
- Added `CHANGELOG.md` (Keep a Changelog + SemVer) and an `AGENTS.md` section on
  keeping it updated.

## Testing

Full suite passes (CI mode, large-dataset tests skipped): **transforms 10/10,
dataset 71/71, datasetdict 44/44**.

## Release note

The new `Dataset` iteration, `begin`/`end`, and `DatasetDict` format methods are
additive features, so this warrants a **0.4.0** minor bump when released (see
`CHANGELOG.md` `[Unreleased]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
