### PR TITLE
Doctested docs guide; fix DatasetDict display and py2jl tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mirroring the `Dataset` methods.
 
 ### Changed
+- `DatasetDict` now has a dedicated `text/plain` display mirroring the Python
+  `datasets.DatasetDict` repr (nested `Dataset` summaries), instead of the generic
+  `AbstractDict` multi-line display.
 - `py2jl` now converts any `PIL.Image.Image` (BMP/GIF/TIFF/WebP and images produced by
   transforms), not only PNG/JPEG. Image modes other than RGB and grayscale (e.g. RGBA,
   CMYK, palette) return the raw array instead of raising an error.
@@ -28,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `jl2numpy` works again with numpy ≥ 2.1, which had broken the DLPack export path. It
   now shares memory through the buffer protocol; the returned numpy array is writable,
   and mutations propagate in both directions.
+- `py2jl` on a Python tuple now returns a proper Julia tuple of converted elements. It
+  previously returned a 1-tuple wrapping an unevaluated generator.
 
 ## [0.3.4]
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@
 
 HuggingFaceDatasets.jl is a non-official julia wrapper around the python package  `datasets` from Hugging Face. `datasets` contains a large collection of machine learning datasets (see [here](https://huggingface.co/datasets) for a list) that this package makes available to the julia ecosystem.
 
-This package is built on top of [PythonCall.jl](https://github.com/cjdoris/PythonCall.jl).
+It wraps the python `datasets.Dataset` and `datasets.DatasetDict` types and:
+
+- forwards every method of the underlying python object, so the full `datasets` API (`map`, `filter`, `shuffle`, `train_test_split`, `cast_column`, …) is available;
+- uses 1-based indexing, julia iteration, and other julia conventions;
+- offers a lazy `"julia"` format that converts observations to native julia types (arrays, images, dictionaries) on access, copylessly when possible.
+
+This package is built on top of [PythonCall.jl](https://github.com/JuliaPy/PythonCall.jl). See the [documentation](https://JuliaGenAI.github.io/HuggingFaceDatasets.jl/dev) for a full guide covering method forwarding, the transform workflow, the array/image orientation caveat, and integration with MLUtils/Flux data loaders.
 
 ## Installation
 
@@ -52,4 +58,4 @@ Dict{String, Vector} with 2 entries:
 
 ## Troubleshooting
 
-- If having problems in resolving the CondaPkg environment, try to set `ENV["JULIA_CONDAPKG_OPENSSL_VERSION"] = true`before loading the package. See more details [here](https://github.com/JuliaPy/CondaPkg.jl?tab=readme-ov-file#preferences)
+- If having problems in resolving the CondaPkg environment, try to set `ENV["JULIA_CONDAPKG_OPENSSL_VERSION"] = true` before loading the package. See more details [here](https://github.com/JuliaPy/CondaPkg.jl?tab=readme-ov-file#preferences)

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
-[sources]
-HuggingFaceDatasets = {path = ".."}
-
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 HuggingFaceDatasets = "d94b9a45-fdf5-4270-b024-5cbb9ef7117d"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+
+[sources]
+HuggingFaceDatasets = {path = ".."}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,8 @@
 using HuggingFaceDatasets
 using Documenter
 
-DocMeta.setdocmeta!(HuggingFaceDatasets, :DocTestSetup, :(using HuggingFaceDatasets); recursive=true)
+DocMeta.setdocmeta!(HuggingFaceDatasets, :DocTestSetup,
+    :(using HuggingFaceDatasets, PythonCall); recursive=true)
 
 makedocs(;
     modules=[HuggingFaceDatasets],
@@ -15,6 +16,7 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        "Guide" => "guide.md",
         "API" => "api.md",
     ],
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -3,8 +3,44 @@ CurrentModule = HuggingFaceDatasets
 CollapsedDocStrings = true
 ```
 
-# API
+# API Reference
 
-```@autodocs
-Modules = [HuggingFaceDatasets]
+This page documents the public types and functions. See the [Guide](@ref) for
+worked examples and background on the transform pipeline.
+
+## Types
+
+```@docs
+Dataset
+DatasetDict
 ```
+
+## Loading
+
+```@docs
+load_dataset
+```
+
+## Formats and transforms
+
+```@docs
+with_format
+set_format!
+reset_format!
+with_jltransform
+set_jltransform!
+```
+
+## Type conversion
+
+```@docs
+py2jl
+numpy2jl
+jl2numpy
+```
+
+## Index
+
+```@index
+```
+</content>

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -1,0 +1,293 @@
+```@meta
+CurrentModule = HuggingFaceDatasets
+DocTestSetup = quote
+    using HuggingFaceDatasets, PythonCall
+end
+```
+
+# Guide
+
+This guide covers how the wrapper relates to the underlying Python `datasets` library,
+the `"julia"` format and the transform pipeline, the array/image orientation caveat, and
+how to feed a dataset into a Julia data loader.
+
+The examples below build small datasets in memory with
+`datasets.Dataset.from_dict` so that they are self-contained and reproducible. In
+practice you will usually obtain a dataset from the Hub with [`load_dataset`](@ref), e.g.
+`load_dataset("ylecun/mnist", split="train")`; everything shown here applies equally to
+those datasets.
+
+## Loading datasets
+
+[`load_dataset`](@ref) forwards all its arguments to the Python
+[`datasets.load_dataset`](https://huggingface.co/docs/datasets/package_reference/loading_methods#datasets.load_dataset)
+function. What it returns depends on the `split` argument:
+
+- without `split`, you get a [`DatasetDict`](@ref) (a dictionary of splits), e.g.
+  `load_dataset("nyu-mll/glue", "sst2")`;
+- with a `split`, you get a single [`Dataset`](@ref), e.g.
+  `load_dataset("nyu-mll/glue", "sst2", split="train")`.
+
+A [`DatasetDict`](@ref) is an `AbstractDict{String, Dataset}`, so `keys`, `values`,
+`haskey`, `get`, and iteration all work as expected:
+
+```jldoctest guide
+julia> train = datasets.Dataset.from_dict(pydict(label=[1, 0, 1, 0]));
+
+julia> test = datasets.Dataset.from_dict(pydict(label=[1, 1]));
+
+julia> dd = DatasetDict(datasets.DatasetDict(pydict(; train, test)))
+DatasetDict({
+    train: Dataset({
+        features: ['label'],
+        num_rows: 4
+    })
+    test: Dataset({
+        features: ['label'],
+        num_rows: 2
+    })
+})
+
+julia> collect(keys(dd))
+2-element Vector{String}:
+ "train"
+ "test"
+
+julia> dd["train"]
+Dataset({
+    features: ['label'],
+    num_rows: 4
+})
+```
+
+A [`Dataset`](@ref) supports 1-based indexing, `length`, `firstindex`/`lastindex`
+(so `ds[begin]` and `ds[end]` work), and iteration over observations:
+
+```jldoctest guide
+julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4])));
+
+julia> length(ds)
+3
+
+julia> ds[begin]
+Python: {'label': 5}
+
+julia> ds[end]
+Python: {'label': 4}
+
+julia> [obs for obs in ds]      # iteration yields one observation at a time
+3-element Vector{Py}:
+ {'label': 5}
+ {'label': 0}
+ {'label': 4}
+```
+
+Indexing with a single integer returns one observation; indexing with a range or vector
+returns a batch, represented as a dictionary mapping each column name to a vector of
+values (see below).
+
+## Method forwarding
+
+Any method or property of the wrapped Python object is available directly on the Julia
+wrapper. Method calls are forwarded to Python, and their results are converted back with
+[`py2jl`](@ref). This means the whole `datasets` API is usable without a dedicated Julia
+binding for each method:
+
+```jldoctest guide
+julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[0, 1, 2, 3])));
+
+julia> ds.select(0:1)                       # keep the first two rows
+Dataset({
+    features: ['label'],
+    num_rows: 2
+})
+
+julia> ds.train_test_split(test_size=0.5, seed=42)
+DatasetDict({
+    train: Dataset({
+        features: ['label'],
+        num_rows: 2
+    })
+    test: Dataset({
+        features: ['label'],
+        num_rows: 2
+    })
+})
+```
+
+Keyword arguments are forwarded as Python keyword arguments, so calls like
+`train_test_split(test_size=0.5)` and `shuffle(seed=0)` behave exactly as in Python.
+
+!!! note "0-based method arguments"
+    Methods forwarded to Python keep Python semantics, including **0-based indices**
+    (e.g. the argument to `select` above). Only the wrapper's own `getindex`/iteration
+    interface is 1-based. Consult the
+    [`datasets` documentation](https://huggingface.co/docs/datasets) for the exact
+    meaning of each method's arguments.
+
+## The `"julia"` format and transforms
+
+By default, indexing a dataset returns Python objects. The package supports the notion
+of a *format* — mirroring `datasets`' own `set_format`/`with_format` — plus an extra
+Julia-side transform.
+
+### Setting a format
+
+[`with_format`](@ref) returns a copy of the dataset with a given format;
+[`set_format!`](@ref) mutates it in place; [`reset_format!`](@ref) clears it.
+
+```jldoctest guide
+julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4])));
+
+julia> ds[1]
+Python: {'label': 5}
+
+julia> ds = with_format(ds, "julia");   # or ds.with_format("julia")
+
+julia> ds[1]
+Dict{String, Int64} with 1 entry:
+  "label" => 5
+
+julia> ds[1:3]                          # a batch: each column becomes a vector
+Dict{String, Vector{Int64}} with 1 entry:
+  "label" => [5, 0, 4]
+```
+
+The special `"julia"` format sets the Julia transform to [`py2jl`](@ref), which
+recursively converts Python containers (lists, tuples, dicts, sets), numpy arrays, and
+PIL images into native Julia values, copylessly when possible. Any other format string
+(e.g. `"numpy"`, `"torch"`, `"pandas"`) is forwarded to the underlying Python
+`set_format`.
+
+### Custom Julia transforms
+
+Beyond the format, you can attach an arbitrary Julia function that runs when indexing,
+with [`with_jltransform`](@ref) / [`set_jltransform!`](@ref). The transform receives the
+raw Python batch, so convert it with [`py2jl`](@ref) first if you want to work with Julia
+types:
+
+```jldoctest guide
+julia> ds = Dataset(datasets.Dataset.from_dict(pydict(x=[1, 2, 3])));
+
+julia> ds = with_jltransform(ds) do batch
+           b = py2jl(batch)          # convert the Python batch to Julia types first
+           b["x"] .* 10
+       end;
+
+julia> ds[1]
+10
+
+julia> ds[1:3]
+3-element Vector{Int64}:
+ 10
+ 20
+ 30
+```
+
+The transform is **always applied to a batch**, even for a single-integer index: `ds[1]`
+is treated as `ds[1:1]` from the transform's point of view, and the single observation is
+then extracted.
+
+Note that the format and the custom transform share the same slot: setting the `"julia"`
+format installs `py2jl` as the transform, and `with_jltransform` then replaces it — which
+is why the transform above calls `py2jl` itself. For layering additional per-batch
+processing on top of the `"julia"` format, prefer `MLUtils.mapobs` (see below), as in the
+[`examples/flux_mnist.jl`](https://github.com/JuliaGenAI/HuggingFaceDatasets.jl/blob/main/examples/flux_mnist.jl)
+script.
+
+The order of operations when you index is:
+
+1. the Python format transform (if any) is applied by `datasets`;
+2. the Julia transform runs on the resulting Python batch (for the `"julia"` format this
+   is [`py2jl`](@ref); otherwise your own function);
+3. for single-integer indexing, one observation is extracted from the batch.
+
+`with_format`/`with_jltransform` return a shallow copy that shares the underlying Arrow
+data with the original but has an independent format, so setting a format or transform on
+the copy does not affect the original.
+
+## Array and image orientation
+
+!!! warning "Arrays come back transposed"
+    numpy and PIL are **row-major**, Julia is **column-major**. The zero-copy conversion
+    ([`numpy2jl`](@ref), via DLPack) therefore returns an array whose **dimensions are
+    reversed** relative to the Python side. A numpy image of shape `(H, W)` becomes a
+    Julia array of size `(W, H)`, and an `(H, W, C)` image becomes `(C, W, H)` with the
+    channel axis first.
+
+For grayscale and RGB images, [`py2jl`](@ref) already wraps the raw array in an
+`ImageCore` view (`Gray{N0f8}` or `RGB{N0f8}`), so you get a proper image type — but note
+the spatial axes are still transposed relative to the Python image. Image modes other
+than RGB and grayscale (RGBA, CMYK, palette, …) are returned as the raw permuted array.
+
+To recover the original orientation, reverse the axes with `permutedims`:
+
+```jldoctest guide
+julia> a = numpy2jl(jl2numpy([1 2 3; 4 5 6]));   # a Julia array, transposed vs. numpy
+
+julia> size(a)
+(2, 3)
+
+julia> size(permutedims(a, reverse(1:ndims(a))))
+(3, 2)
+```
+
+For an image view, use `ImageCore.channelview` to get the underlying numeric array and
+permute as needed. Which orientation you want depends on downstream use; for batching
+into a Flux model you typically stack `channelview` outputs with the layout your model
+expects (see the MNIST example below).
+
+The reverse conversion [`jl2numpy`](@ref) is symmetric: it shares memory through the
+buffer protocol and reverses the axes, so `numpy2jl(jl2numpy(x)) == x` holds and writes
+propagate in both directions.
+
+## Integration with MLUtils and data loaders
+
+A [`Dataset`](@ref) implements the length/`getindex` interface expected by
+[MLUtils.jl](https://github.com/JuliaML/MLUtils.jl), so `numobs`, `getobs`, `mapobs`, and
+data loaders such as `Flux.DataLoader` work directly:
+
+```jldoctest guide
+julia> using MLUtils
+
+julia> ds = Dataset(datasets.Dataset.from_dict(pydict(x=[1, 2, 3, 4]))).with_format("julia");
+
+julia> numobs(ds)
+4
+
+julia> getobs(ds, 2)
+Dict{String, Int64} with 1 entry:
+  "x" => 2
+
+julia> mapped = mapobs(batch -> batch["x"] .* 10, ds);   # lazily transform observations
+
+julia> getobs(mapped, 1:4)
+4-element Vector{Int64}:
+ 10
+ 20
+ 30
+ 40
+```
+
+Putting it together for MNIST, you would set the `"julia"` format, `mapobs` a transform
+that turns each image batch into a numeric array (`ImageCore.channelview` +
+`Flux.batch`, plus `Flux.onehotbatch` for the labels), then hand the result to a
+`Flux.DataLoader`:
+
+```julia-repl
+julia> train_data = load_dataset("ylecun/mnist", split="train").with_format("julia");
+
+julia> train_data = mapobs(mnist_transform, train_data)[:];   # lazily map, then materialize
+
+julia> train_loader = Flux.DataLoader(train_data; batchsize=128, shuffle=true);
+```
+
+Materializing with `[:]` loads the whole (transformed) dataset into memory, which is
+fastest for small datasets like MNIST. Dropping the `[:]` keeps loading on-the-fly, which
+is slower per epoch but avoids holding everything in memory.
+
+This snippet needs the Hub and the Flux/ImageCore stack, so it is not run as a doctest; a
+complete, runnable version — including `mnist_transform` and the training loop — lives in
+[`examples/flux_mnist.jl`](https://github.com/JuliaGenAI/HuggingFaceDatasets.jl/blob/main/examples/flux_mnist.jl).
+```
+</content>

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,32 +1,49 @@
 ```@meta
 CurrentModule = HuggingFaceDatasets
+DocTestSetup = quote
+    using HuggingFaceDatasets, PythonCall
+end
 ```
 
 # HuggingFaceDatasets
 
 Documentation for [HuggingFaceDatasets](https://github.com/JuliaGenAI/HuggingFaceDatasets.jl).
 
+HuggingFaceDatasets.jl is a non-official Julia wrapper around the Python package
+[`datasets`](https://huggingface.co/docs/datasets) from Hugging Face. `datasets`
+provides access to a large collection of machine learning datasets
+(see [the Hub](https://huggingface.co/datasets) for the full list), which this
+package makes available to the Julia ecosystem.
 
-HuggingFaceDatasets.jl is a non-official julia wrapper around the python package  `datasets` from Hugging Face. `datasets` contains a large collection of machine learning datasets (see [here](https://huggingface.co/datasets) for a list) that this package makes available to the julia ecosystem.
+The package wraps the Python `datasets.Dataset` and `datasets.DatasetDict` types and:
 
-This package is built on top of [PythonCall.jl](https://github.com/cjdoris/PythonCall.jl).
+- forwards every method of the underlying Python object, so the full `datasets` API
+  (`map`, `filter`, `shuffle`, `train_test_split`, `cast_column`, …) is available;
+- uses 1-based indexing, Julia iteration, and other Julia conventions;
+- offers a lazy `"julia"` format that converts observations to native Julia types
+  (arrays, images, dictionaries) on access, copylessly when possible.
+
+It is built on top of [PythonCall.jl](https://github.com/JuliaPy/PythonCall.jl).
 
 ## Installation
 
-HuggingFaceDatasets.jl is a registered Julia package. You can easily install it through the package manager:
+HuggingFaceDatasets.jl is a registered Julia package. Install it through the package
+manager:
 
 ```julia
 pkg> add HuggingFaceDatasets
 ```
 
-## Usage
+The Python `datasets` package and its dependencies are installed automatically through
+[CondaPkg.jl](https://github.com/JuliaPy/CondaPkg.jl) the first time the package is
+loaded; no manual Python setup is required.
 
-HuggingFaceDatasets.jl provides wrappers around types from the `datasets` python package (e.g. `Dataset` and `DatasetDict`) along with a few related methods.
+## Quickstart
 
-Check out the `examples/` folder for usage examples.
+Fetch a dataset from the Hub with [`load_dataset`](@ref) and index into it. By default
+observations are returned as Python objects:
 
 ```julia
-# Returned observations are now julia objects
 julia> using HuggingFaceDatasets
 
 julia> train_data = load_dataset("ylecun/mnist", split = "train")
@@ -37,19 +54,40 @@ Dataset({
 
 julia> train_data[1]
 Python: {'image': <PIL.PngImagePlugin.PngImageFile image mode=L size=28x28 at 0x3340B0290>, 'label': 5}
-
-julia> length(train_data)
-60000
-
-julia> train_data = load_dataset("ylecun/mnist", split = "train").with_format("julia");
-
-julia> train_data[1] # Returned observations are now julia objects
-Dict{String, Any} with 2 entries:
-  "label" => 5
-  "image" => Gray{N0f8}[0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]
-
-julia> train_data[1:2]
-Dict{String, Vector} with 2 entries:
-  "label" => [5, 0]
-  "image" => ReinterpretArray{Gray{N0f8}, 2, UInt8, Matrix{UInt8}, false}[[0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0…
 ```
+
+Apply the `"julia"` format to have observations converted to native Julia types
+(dictionaries, arrays, images) on access. The example below builds a small dataset in
+memory so it is reproducible, but the same applies to any dataset from the Hub:
+
+```jldoctest
+julia> using HuggingFaceDatasets, PythonCall
+
+julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4])));
+
+julia> ds[1]                            # a Python object by default
+Python: {'label': 5}
+
+julia> ds = ds.with_format("julia");    # convert observations to Julia types
+
+julia> ds[1]
+Dict{String, Int64} with 1 entry:
+  "label" => 5
+
+julia> ds[1:3]                          # a batch: each column becomes a vector
+Dict{String, Vector{Int64}} with 1 entry:
+  "label" => [5, 0, 4]
+```
+
+See the [Guide](@ref) for the transform workflow, method forwarding, the array/image
+orientation caveat, and integration with MLUtils/Flux data loaders. Runnable examples
+live in the
+[`examples/`](https://github.com/JuliaGenAI/HuggingFaceDatasets.jl/tree/main/examples)
+folder.
+
+## Troubleshooting
+
+- If you have problems resolving the CondaPkg environment, try setting
+  `ENV["JULIA_CONDAPKG_OPENSSL_VERSION"] = true` before loading the package. See more
+  details [here](https://github.com/JuliaPy/CondaPkg.jl?tab=readme-ov-file#preferences).
+</content>

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -3,11 +3,43 @@
 
 A Julia wrapper around an object of the python `datasets.Dataset` class.
 
-Provides: 
+Provides:
 - 1-based indexing.
 - All python class' methods from  `datasets.Dataset`.
 
-See also [`load_dataset`](@ref) and [`DatasetDict`](@ref).
+Usually constructed via [`load_dataset`](@ref), but any `datasets.Dataset` object can
+be wrapped directly.
+
+See also [`load_dataset`](@ref), [`DatasetDict`](@ref), and [`with_format`](@ref).
+
+# Examples
+
+```jldoctest
+julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4])))
+Dataset({
+    features: ['label'],
+    num_rows: 3
+})
+
+julia> length(ds)
+3
+
+julia> ds[1]      # a single observation, as a Python object
+Python: {'label': 5}
+
+julia> ds[end]
+Python: {'label': 4}
+
+julia> ds = with_format(ds, "julia");   # convert observations to Julia types
+
+julia> ds[1]
+Dict{String, Int64} with 1 entry:
+  "label" => 5
+
+julia> ds[1:3]    # a range or vector returns a batch (columns -> vectors)
+Dict{String, Vector{Int64}} with 1 entry:
+  "label" => [5, 0, 4]
+```
 """
 mutable struct Dataset
     pyds::Py
@@ -104,18 +136,17 @@ See also [`set_format!`](@ref).
 
 # Examples
 
-```julia
-julia> ds = load_dataset("ylecun/mnist", split="test");
+```jldoctest
+julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4])));
 
 julia> ds[1]
-Python dict: {'image': <PIL.PngImagePlugin.PngImageFile image mode=L size=28x28 at 0x2B5B4C1F0>, 'label': 7}
+Python: {'label': 5}
 
 julia> ds = with_format(ds, "julia");
 
 julia> ds[1]
-Dict{String, Any} with 2 entries:
-  "label" => 7
-  "image" => UInt8[0x00 0x00 … 0x00 0x00; 0x00 0x00 … 0x00 0x00; … ; 0x00 0x00 … 0x00 0x00; 0x00 0x00 … 0x00 0x00]
+Dict{String, Int64} with 1 entry:
+  "label" => 5
 ```
 """
 function with_format(ds::Dataset, format::AbstractString)

--- a/src/datasetdict.jl
+++ b/src/datasetdict.jl
@@ -8,7 +8,44 @@ The `jltransform` is applied to each [`Dataset`](@ref).
 The [`py2jl`](@ref) transform provided by this package
 converts python types to julia types.
 
+A `DatasetDict` is an `AbstractDict{String, Dataset}`, so `keys`, `values`, `haskey`,
+`get`, and iteration work as expected.
+
 See also [`load_dataset`](@ref) and [`Dataset`](@ref).
+
+# Examples
+
+```jldoctest
+julia> train = datasets.Dataset.from_dict(pydict(label=[1, 0, 1, 0]));
+
+julia> test = datasets.Dataset.from_dict(pydict(label=[1, 1]));
+
+julia> dd = DatasetDict(datasets.DatasetDict(pydict(; train, test)))
+DatasetDict({
+    train: Dataset({
+        features: ['label'],
+        num_rows: 4
+    })
+    test: Dataset({
+        features: ['label'],
+        num_rows: 2
+    })
+})
+
+julia> collect(keys(dd))
+2-element Vector{String}:
+ "train"
+ "test"
+
+julia> dd["train"]
+Dataset({
+    features: ['label'],
+    num_rows: 4
+})
+
+julia> haskey(dd, "validation")
+false
+```
 """
 mutable struct DatasetDict <: AbstractDict{String, Dataset}
     pyd::Py
@@ -74,6 +111,11 @@ function Base.copy(d::DatasetDict)
 end
 
 Base.show(io::IO, ds::DatasetDict) = print(io, ds.pyd)
+
+# `DatasetDict` is an `AbstractDict`, so without this method the REPL would use the
+# generic `AbstractDict` multi-line display. Show the Python-style repr instead, which
+# mirrors `datasets.DatasetDict` and nests the `Dataset` summaries.
+Base.show(io::IO, ::MIME"text/plain", ds::DatasetDict) = print(io, ds.pyd)
 
 """
     with_jltransform(d::DatasetDict, transform)

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -5,6 +5,19 @@
 Convert Python types to Julia types. It will recursively traverse built-in python
 containers such as lists, tuples, dicts, and sets, and convert all nested objects.
 On the leaves, it will call either `pyconvert(Any, x)` or [`numpy2jl`](@ref).
+
+# Examples
+
+```jldoctest
+julia> py2jl(pylist([1, 2, 3]))
+3-element Vector{Int64}:
+ 1
+ 2
+ 3
+
+julia> py2jl(pytuple((1, pylist([2, 3]))))
+(1, [2, 3])
+```
 """
 py2jl(x) = pyconvert(Any, x)
 
@@ -18,7 +31,7 @@ function py2jl(x::Py)
     elseif pyisinstance(x, pytype(pylist()))
         return [py2jl(x) for x in x]
     elseif pyisinstance(x, pytype(pytuple()))
-        return tuple(py2jl(x) for x in x)
+        return Tuple(py2jl(el) for el in x)
     elseif pyisinstance(x, pytype(pydict()))
         return Dict(py2jl(k) => py2jl(v) for (k, v) in x.items())
     elseif pyisinstance(x, pytype(pyset()))
@@ -53,6 +66,17 @@ For row major python arrays, the returned Julia array has permuted dimensions.
 
 This function is called by [`py2jl`](@ref).
 See also [`jl2numpy`](@ref).
+
+# Examples
+
+```jldoctest
+julia> y = jl2numpy([1 2 3; 4 5 6]);   # a 3×2 numpy array
+
+julia> numpy2jl(y)                      # back to a 2×3 Julia array
+2×3 Matrix{Int64}:
+ 1  2  3
+ 4  5  6
+```
 """
 function numpy2jl(x::Py)
     return DLPack.from_dlpack(x)
@@ -67,6 +91,20 @@ Julia array (and vice versa). The returned numpy array has permuted dimensions w
 respect to the input Julia array, since numpy is row-major and Julia is column-major.
 
 See also [`numpy2jl`](@ref).
+
+# Examples
+
+```jldoctest
+julia> x = [1 2 3; 4 5 6];   # a 2×3 Julia array
+
+julia> y = jl2numpy(x);      # numpy is row-major, so the axes are reversed
+
+julia> y.shape
+Python: (3, 2)
+
+julia> numpy2jl(y) == x
+true
+```
 """
 function jl2numpy(x::AbstractArray)
     # `np.asarray(Py(x))` exposes `x`'s memory to numpy through the buffer protocol

--- a/test/datasetdict.jl
+++ b/test/datasetdict.jl
@@ -22,6 +22,15 @@ mnist = load_dataset("ylecun/mnist")
     @test Set(k for (k, v) in mnist) == Set(["train", "test"])
 end
 
+@testset "display mirrors python repr" begin
+    # `text/plain` show should match the Python `datasets.DatasetDict` repr, not the
+    # generic `AbstractDict` multi-line display.
+    s = sprint(show, MIME("text/plain"), mnist)
+    @test startswith(s, "DatasetDict({")
+    @test occursin("train: Dataset({", s)
+    @test s == sprint(show, mnist)   # same as the 2-arg show
+end
+
 @testset "indexing, no (jl)transform by default" begin
     @test_throws MethodError mnist[1]
     @test mnist["test"] isa Dataset

--- a/test/no_ci.jl
+++ b/test/no_ci.jl
@@ -25,8 +25,8 @@ end
         @test ds[1]["objects"] isa Dict{String, Vector}
         imgs = ds[1:2]["image"]
         @test imgs isa Vector{<:AbstractArray}
-        @test imgs isa Vector{<:AbstractMatrix} broken=true
-        @test imgs isa Vector{<:AbstractMatrix{RGB{N0f8}}} broken=true
+        @test imgs isa Vector{<:AbstractMatrix}
+        @test imgs isa Vector{<:AbstractMatrix{RGB{N0f8}}}
         @test size(imgs[1]) == (1920, 1088)
         @test imgs[1] isa AbstractMatrix{RGB{N0f8}}
         @test ds[1:2]["objects"] isa Vector{Dict{String, Vector}}

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -4,6 +4,12 @@
 
     d = pydict(["a" => 1, "b" => 2])
     @test py2jl(d) isa Dict{String,Int}
+
+    # tuples are converted element-wise to a Julia tuple (regression: used to return a
+    # 1-tuple wrapping an unevaluated generator)
+    t = py2jl(pytuple((1, pylist([2, 3]))))
+    @test t isa Tuple
+    @test t == (1, [2, 3])
 end
 
 @testset "jl2numpy / numpy2jl" begin


### PR DESCRIPTION
Stacked on #44 (`cl/review-fixes`). Continues the review follow-ups: fleshes out the documentation, makes every example a passing doctest, and fixes two bugs surfaced along the way.

## Documentation
- **New [`docs/src/guide.md`](docs/src/guide.md)** — loading, method forwarding (with the 0-based-argument caveat), the `"julia"` format + transform pipeline, the array/image orientation caveat with the `permutedims` recipe, and MLUtils/`getobs`/`mapobs`/`DataLoader` integration.
- **[`docs/src/index.md`](docs/src/index.md)** reworked into an overview + quickstart (was a README duplicate); **[`docs/src/api.md`](docs/src/api.md)** groups docstrings by topic with an `@index` (was a bare `@autodocs`); README gains a features summary and a pointer to the guide.
- **Everything is doctested.** All executable examples in the docstrings, guide, and index are `jldoctest` blocks that run under `makedocs` and pass. They use small in-memory datasets (`datasets.Dataset.from_dict`) so they are deterministic and offline. Added `PythonCall` to the docs env plus a `DocTestSetup`. The only non-executed snippets are the `load_dataset` Hub intro and the Flux training loop (network / heavy deps / non-reproducible output), which link to [`examples/flux_mnist.jl`](examples/flux_mnist.jl).

## Bug fixes (surfaced by doctesting)
- **`DatasetDict` display** — after it became an `AbstractDict` (#43), the REPL fell back to the generic dict display. Added `show(::IO, ::MIME"text/plain", ::DatasetDict)` so it mirrors the Python `datasets.DatasetDict` repr again.
- **`py2jl` on Python tuples** — `tuple(gen)` wrapped an unevaluated generator instead of splatting (`py2jl(pytuple((1,2)))` → `(Base.Generator…,)`). Fixed to `Tuple(py2jl(el) for el in x)`.
- **`test/no_ci.jl`** — promoted two now-passing `broken=true` image-batch assertions to `@test`.

## Tests
Regression tests added for both bugs. Full suite: transforms 12/12, dataset 71/71, datasetdict 47/47, larger datasets 16/16 — all green. Docs build with all doctests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)