### PR TITLE
Make DatasetDict merge/filter return a DatasetDict

### DIFF
--- a/src/datasetdict.jl
+++ b/src/datasetdict.jl
@@ -93,6 +93,26 @@ Base.iterate(d::DatasetDict, state...) = iterate(pairs(d), state...)
 
 Base.get(d::DatasetDict, k::AbstractString, default) = haskey(d, k) ? d[k] : default
 
+# The generic `AbstractDict` `merge`/`filter` build the result with `empty(d)`, which
+# returns a plain `Dict` and drops the wrapper. Override them to return a `DatasetDict`
+# backed by a fresh `datasets.DatasetDict`, preserving `d`'s `jltransform`.
+_pyds(v::Dataset) = getfield(v, :pyds)
+_pyds(v::Py) = v
+
+function _wrap_pairs(itr, jltransform)
+    pyd = datasets.DatasetDict()
+    for (k, v) in itr
+        pyd[String(k)] = _pyds(v)
+    end
+    return DatasetDict(pyd, jltransform)
+end
+
+Base.filter(f, d::DatasetDict) = _wrap_pairs(Iterators.filter(f, pairs(d)), d.jltransform)
+
+function Base.merge(d::DatasetDict, others::AbstractDict...)
+    return _wrap_pairs(Iterators.flatten((pairs(d), map(pairs, others)...)), d.jltransform)
+end
+
 function Base.deepcopy_internal(d::DatasetDict, stackdict::IdDict)
     haskey(stackdict, d) && return stackdict[d]::DatasetDict
     pyd = pycopy.deepcopy(getfield(d, :pyd))

--- a/test/datasetdict.jl
+++ b/test/datasetdict.jl
@@ -91,6 +91,30 @@ end
     @test mnist["test"].format["type"] === nothing          # original untouched
 end
 
+@testset "merge / filter preserve the wrapper type" begin
+    # `merge`/`filter` must return a `DatasetDict`, not a plain `Dict{String,Dataset}`.
+    f = filter(p -> p.first == "train", mnist)
+    @test f isa DatasetDict
+    @test collect(keys(f)) == ["train"]
+
+    extra = load_dataset("ylecun/mnist")["test"]   # a lone `Dataset`
+    m = merge(mnist, Dict("extra" => extra))
+    @test m isa DatasetDict
+    @test Set(keys(m)) == Set(["train", "test", "extra"])
+
+    # later dicts win, matching `Base.merge` semantics
+    m2 = merge(mnist, Dict("train" => extra))
+    @test m2 isa DatasetDict
+    @test length(m2["train"]) == length(extra)
+
+    # the `jltransform` of the first argument is carried over
+    dj = with_format(mnist, "julia")
+    fj = filter(p -> p.first == "test", dj)
+    @test fj isa DatasetDict
+    @test fj["test"][1] isa Dict
+    @test fj["test"][1]["label"] isa Int
+end
+
 @testset "set_jltransform!" begin
     d = deepcopy(mnist)
     set_jltransform!(d) do x


### PR DESCRIPTION
## Problem

`DatasetDict <: AbstractDict{String, Dataset}`, so `merge`/`filter` fell back to Base's generic `AbstractDict` implementations. Those build the result with `empty(d)`, which returns a plain `Dict` — so `merge`/`filter` silently dropped the wrapper type:

```julia
julia> filter(p -> p.first == "train", dd) isa DatasetDict
false   # got Dict{String, Dataset}
```

## Fix

Add `Base.filter`/`Base.merge` methods for `DatasetDict` that return a `DatasetDict` backed by a fresh `datasets.DatasetDict`, via a small `_wrap_pairs` helper. Behaviour:

- **Type preserved** — both now return a `DatasetDict`.
- **`jltransform` preserved** — the first argument's transform (e.g. the `"julia"` format) carries over to the result.
- **`Base.merge` semantics** — later dicts win on key collisions; `others` may be `DatasetDict` or plain `Dict{String,Dataset}`.

## Tests

New testset in `test/datasetdict.jl` (9 assertions, passing) covering return type, key union on merge, later-wins override, and `jltransform` propagation through `filter`.

## Note

A `DatasetDict` carries a single `jltransform` for all splits, so `merge` adopts the first argument's transform; if merged dicts have different transforms, the others' are dropped — consistent with the wrapper's single-transform model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)