### PR TITLE
Support datasets 4: lazy Column for column access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `Column`, a lazy 1-based `AbstractVector` view over a single dataset column. It
+  wraps the python `datasets.Column` returned by `dataset[column_name]` (datasets ≥ 4)
+  and converts elements with `py2jl` on access; `collect(col)` materializes it.
 - `Base.firstindex`/`Base.lastindex` for `Dataset`, so `ds[begin]` and `ds[end]` work.
 - `Base.iterate` for `Dataset`; it iterates over observations, enabling
   `for obs in ds`, `collect(ds)`, and comprehensions.
@@ -15,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mirroring the `Dataset` methods.
 
 ### Changed
+- Bumped the `datasets` Python dependency to `>=4.0, <5`.
+- `py2jl` on a `datasets.Column` (and hence string indexing of a julia-formatted
+  `Dataset`, e.g. `ds["label"]`) now returns a lazy `Column` view instead of eagerly
+  materializing the whole column. The result still behaves like a vector (indexing,
+  slicing, iteration, broadcasting, comparison); call `collect` to get a plain `Vector`.
 - `DatasetDict` now has a dedicated `text/plain` display mirroring the Python
   `datasets.DatasetDict` repr (nested `Dataset` summaries), instead of the generic
   `AbstractDict` multi-line display.

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,7 +1,7 @@
 channels = ["conda-forge"]
 
 [deps]
-datasets = ">=3.0, <4"
+datasets = ">=4.0, <5"
 numpy = ""
 pillow = ""
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -13,6 +13,7 @@ worked examples and background on the transform pipeline.
 ```@docs
 Dataset
 DatasetDict
+Column
 ```
 
 ## Loading

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -151,7 +151,17 @@ Dict{String, Int64} with 1 entry:
 julia> ds[1:3]                          # a batch: each column becomes a vector
 Dict{String, Vector{Int64}} with 1 entry:
   "label" => [5, 0, 4]
+
+julia> ds["label"]                      # a whole column: a lazy `Column` view
+3-element HuggingFaceDatasets.Column{Int64}:
+ 5
+ 0
+ 4
 ```
+
+Indexing by column name returns a lazy [`Column`](@ref): it behaves like a vector
+(indexing, slicing, iteration, broadcasting) but converts elements only on access, so
+the whole column is never materialized at once. Call `collect` to get a plain `Vector`.
 
 The special `"julia"` format sets the Julia transform to [`py2jl`](@ref), which
 recursively converts Python containers (lists, tuples, dicts, sets), numpy arrays, and

--- a/src/HuggingFaceDatasets.jl
+++ b/src/HuggingFaceDatasets.jl
@@ -28,6 +28,8 @@ export Dataset,
 include("datasetdict.jl")
 export DatasetDict
 
+include("column.jl")
+
 include("transforms.jl")
 export py2jl, 
     jl2numpy, 

--- a/src/column.jl
+++ b/src/column.jl
@@ -1,0 +1,81 @@
+"""
+    Column{T} <: AbstractVector{T}
+
+A lazy, 1-based vector view over a single column of a [`Dataset`]. It wraps the
+python `datasets.Column` object that `dataset[column_name]` returns
+and converts each element from python to julia with [`py2jl`](@ref) only when it
+is accessed, so the whole column is never materialized at once.
+
+Because `Column <: AbstractVector`, it indexes, slices, iterates, broadcasts,
+compares, and `collect`s like an ordinary vector; `collect(col)` materializes it
+into a plain `Vector`. The element type `T` is inferred from the first element
+(`Any` if the column is empty).
+
+Returned by [`py2jl`](@ref) on a `datasets.Column`, and hence by string indexing
+of a julia-formatted [`Dataset`], e.g. `ds["label"]`.
+
+# Examples
+
+```jldoctest
+julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4])));
+
+julia> ds = with_format(ds, "julia");
+
+julia> col = ds["label"]
+3-element HuggingFaceDatasets.Column{Int64}:
+ 5
+ 0
+ 4
+
+julia> col[2]
+0
+
+julia> col[1:2]
+2-element Vector{Int64}:
+ 5
+ 0
+
+julia> collect(col)
+3-element Vector{Int64}:
+ 5
+ 0
+ 4
+```
+"""
+struct Column{T} <: AbstractVector{T}
+    pyobj::Py
+end
+
+function Column(pyobj::Py)
+    n = pylen(pyobj)
+    T = n == 0 ? Any : typeof(py2jl(pyobj[0]))
+    return Column{T}(pyobj)
+end
+
+# The underlying python `datasets.Column`.
+pyobj(c::Column) = getfield(c, :pyobj)
+
+Base.size(c::Column) = (pylen(pyobj(c)),)
+
+function Base.getindex(c::Column, i::Integer)
+    @boundscheck checkbounds(c, i)
+    return py2jl(pyobj(c)[i - 1])
+end
+
+# Fetch a batch of indices in a single python round-trip instead of one per element.
+function Base.getindex(c::Column, ii::AbstractVector{<:Integer})
+    @boundscheck checkbounds(c, ii)
+    return py2jl(pyobj(c)[pylist(Int[i - 1 for i in ii])])
+end
+
+# Logical indexing (`Bool <: Integer`, so this must be handled separately).
+function Base.getindex(c::Column, mask::AbstractVector{Bool})
+    @boundscheck length(mask) == length(c) || throw(BoundsError(c, mask))
+    return c[findall(mask)]
+end
+
+# Nested columns (struct features): `col["field"]` returns another lazy `Column`.
+Base.getindex(c::Column, name::AbstractString) = Column(pyobj(c)[name])
+
+# Convert the whole python column in one shot rather than element by element.
+Base.collect(c::Column) = py2jl(pylist(pyobj(c)))

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -6,6 +6,10 @@ Convert Python types to Julia types. It will recursively traverse built-in pytho
 containers such as lists, tuples, dicts, and sets, and convert all nested objects.
 On the leaves, it will call either `pyconvert(Any, x)` or [`numpy2jl`](@ref).
 
+A `datasets.Column` (the lazy column view returned by `dataset[column_name]`) is
+wrapped in a lazy [`Column`](@ref), whose elements are converted on access rather
+than all at once.
+
 # Examples
 
 ```jldoctest
@@ -27,6 +31,11 @@ function py2jl(x::Py)
         return Dataset(x)
     elseif pyisinstance(x, datasets.DatasetDict)
         return DatasetDict(x)
+    # handle datasets.Column (the lazy column view that `dataset[column_name]`
+    # returns in datasets >= 4) by wrapping it in a lazy `Column` rather than
+    # materializing it here
+    elseif pyisinstance(x, datasets.Column)
+        return Column(x)
     # handle list, tuple, dict, and set
     elseif pyisinstance(x, pytype(pylist()))
         return [py2jl(x) for x in x]

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -68,8 +68,17 @@ end
 @testset "with_format(julia) - mnist" begin
     ds = with_format(mnist, "julia")
     @test ds.format["type"] === nothing
-    @test ds["label"] isa Vector{Int}
-    @test length(ds["label"]) == 10000
+
+    # `ds[column]` returns a lazy `Column` view, not a materialized vector
+    col = ds["label"]
+    @test col isa HuggingFaceDatasets.Column{Int}
+    @test col isa AbstractVector{Int}
+    @test length(col) == 10000
+    @test col[1] == 7
+    @test col[1:2] == [7, 2]
+    @test col[[2, 1]] == [2, 7]
+    @test collect(col) isa Vector{Int}
+    @test length(collect(col)) == 10000
 
     x = ds[1]
     @test x isa Dict

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -10,6 +10,21 @@
     t = py2jl(pytuple((1, pylist([2, 3]))))
     @test t isa Tuple
     @test t == (1, [2, 3])
+
+    # a datasets.Column (datasets >= 4) is wrapped in a lazy `Column`, converting
+    # elements on access rather than materializing the whole column
+    pyds = datasets.Dataset.from_dict(pydict(label = [5, 0, 4]))
+    col = py2jl(pyds["label"])
+    @test col isa HuggingFaceDatasets.Column{Int}
+    @test col isa AbstractVector{Int}
+    @test size(col) == (3,)
+    @test col[1] == 5
+    @test col[2:3] == [0, 4]
+    @test col[[3, 1]] == [4, 5]
+    @test col[[true, false, true]] == [5, 4]   # logical indexing (Bool <: Integer)
+    @test col == [5, 0, 4]
+    @test collect(col) isa Vector{Int}
+    @test collect(col) == [5, 0, 4]
 end
 
 @testset "jl2numpy / numpy2jl" begin


### PR DESCRIPTION
## Summary

Bumps the `datasets` Python dependency to `>=4.0, <5` and adapts to the one
breaking change that affects this package: in datasets 4, `dataset[column_name]`
returns a lazy `datasets.Column` view instead of a materialized list.

`py2jl` didn't recognize the `Column` and fell through to `pyconvert(Any, …)`, so
a julia-formatted `ds["label"]` came back as an untyped `Vector{Any}` (was
`Vector{Int}` on datasets 3).

## Approach

Rather than re-materializing the column (which would defeat the memory-efficiency
intent behind the upstream change — *"load one cell without bringing the full
column in memory"*), this adds a lazy wrapper:

- **`Column{T} <: AbstractVector{T}`** (`src/column.jl`) — wraps the python
  `datasets.Column` and converts elements with `py2jl` **on access**, so the whole
  column is never materialized at once. Because it's an `AbstractVector`, it
  indexes, slices, iterates, broadcasts, compares, and `collect`s like an ordinary
  vector; `collect` materializes in a single python round-trip. The element type
  `T` is inferred from the first element (`Any` for an empty column).
- Indexing support: integer, range/vector (one round-trip), logical
  (`Bool <: Integer`, handled explicitly), and nested struct columns
  (`col["field"]` → another lazy `Column`).
- **`py2jl(::datasets.Column)`** now returns a `Column`, so string indexing of a
  julia-formatted `Dataset` (e.g. `ds["label"]`) is lazy.

## Tests & docs

- Full suite passes on datasets 4.8, including the large-dataset tests CI skips
  (mnist, glue, cifar10, beans, cppe-5).
- Doctests (docstrings + guide) pass.
- No Python deprecation warnings from the package's API surface.
- Added `py2jl`→`Column` coverage (incl. slicing and logical indexing) and updated
  the mnist column test.
- Documented `Column` in the API reference and the guide; updated `CHANGELOG.md`.

## Notes

- Behavioral change: `ds["label"]` now returns a lazy `Column` rather than a
  `Vector`. It still behaves like a vector; call `collect` for a plain `Vector`.
- Follow-up design discussion (whether the python format and the julia transform
  should be decoupled) is tracked in #48 — no interface change is made here.
- datasets 4.0 also removed script-based dataset loading (`trust_remote_code`);
  this package never used it and all test/example datasets are Parquet-based, so
  there's no impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
