### PR TITLE
Unify internal Python-handle field name to `py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CMYK, palette) return the raw array instead of raising an error.
 - Invalid arguments now raise `ArgumentError`, and out-of-range indices raise
   `BoundsError`, instead of `AssertionError`.
+- Renamed the internal field holding the wrapped Python object to `py` on both
+  `Dataset` (was `pyds`) and `DatasetDict` (was `pyd`), for consistency. This field is
+  not part of the public API (it is shadowed by `getproperty`), so the change is
+  non-breaking for documented usage.
 
 ### Fixed
 - Keyword arguments are correctly forwarded to wrapped Python methods (e.g.

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -42,21 +42,21 @@ Dict{String, Vector{Int64}} with 1 entry:
 ```
 """
 mutable struct Dataset
-    pyds::Py
+    py::Py
     jltransform
 
-    function Dataset(pyds::Py, jltransform = identity)
-        if !pyisinstance(pyds, datasets.Dataset)
-            throw(ArgumentError("expected a `datasets.Dataset`, got $(pytype(pyds))"))
+    function Dataset(py::Py, jltransform = identity)
+        if !pyisinstance(py, datasets.Dataset)
+            throw(ArgumentError("expected a `datasets.Dataset`, got $(pytype(py))"))
         end
-        return new(pyds, jltransform)
+        return new(py, jltransform)
     end
 end
 
 ## TODO make it work with arbitrary order tensors
 # function Dataset(d::Dict; jltransform = identity)
-#     pyds = datasets.Dataset.from_dict(d)
-#     return Dataset(pyds, jltransform)
+#     py = datasets.Dataset.from_dict(d)
+#     return Dataset(py, jltransform)
 # end
 
 function Base.getproperty(ds::Dataset, s::Symbol)
@@ -65,7 +65,7 @@ function Base.getproperty(ds::Dataset, s::Symbol)
     elseif s === :with_format
         return format -> with_format(ds, format)
     else
-        res = getproperty(getfield(ds, :pyds), s)
+        res = getproperty(getfield(ds, :py), s)
         if pycallable(res)
             return CallableWrapper(res)
         else
@@ -74,7 +74,7 @@ function Base.getproperty(ds::Dataset, s::Symbol)
     end
 end
 
-Base.length(ds::Dataset) = length(ds.pyds)
+Base.length(ds::Dataset) = length(ds.py)
 
 Base.firstindex(ds::Dataset) = 1
 Base.lastindex(ds::Dataset) = length(ds)
@@ -90,7 +90,7 @@ Base.getindex(ds::Dataset, ::Colon) = ds[1:length(ds)]
 
 function Base.getindex(ds::Dataset, i::AbstractVector{<:Integer})
     all(≥(1), i) || throw(BoundsError(ds, i))
-    x = getfield(ds, :pyds)[i .- 1]
+    x = getfield(ds, :py)[i .- 1]
     return ds.jltransform(x)
 end
 
@@ -100,16 +100,16 @@ function Base.getindex(ds::Dataset, i::Integer)
 end
 
 function Base.getindex(ds::Dataset, i::AbstractString)
-    x = ds.pyds[i]
+    x = ds.py[i]
     d = @py {i: x}
     return ds.jltransform(d)[i]
 end
 
 function Base.deepcopy_internal(ds::Dataset, stackdict::IdDict)
     haskey(stackdict, ds) && return stackdict[ds]::Dataset
-    pyds = pycopy.deepcopy(getfield(ds, :pyds))
+    py = pycopy.deepcopy(getfield(ds, :py))
     jltransform = Base.deepcopy_internal(getfield(ds, :jltransform), stackdict)
-    ds2 = Dataset(pyds, jltransform)
+    ds2 = Dataset(py, jltransform)
     stackdict[ds] = ds2
     return ds2
 end
@@ -118,11 +118,11 @@ end
 # but has an independent format, so `set_format!`/`set_jltransform!` on the copy
 # do not affect the original. Used internally by the copy-on-write helpers.
 function Base.copy(ds::Dataset)
-    pyds = pycopy.copy(getfield(ds, :pyds))
-    return Dataset(pyds, getfield(ds, :jltransform))
+    py = pycopy.copy(getfield(ds, :py))
+    return Dataset(py, getfield(ds, :jltransform))
 end
 
-Base.show(io::IO, ds::Dataset) = print(io, ds.pyds)
+Base.show(io::IO, ds::Dataset) = print(io, ds.py)
 
 """
     with_format(ds::Dataset, format)
@@ -162,10 +162,10 @@ version of [`with_format`](@ref).
 """
 function set_format!(ds::Dataset, format)
     if format == "julia"
-        ds.pyds.reset_format() # or d.pyd.set_format("python")
+        ds.py.reset_format() # or ds.py.set_format("python")
         ds.jltransform = py2jl
     else
-        ds.pyds.set_format(format)
+        ds.py.set_format(format)
         ds.jltransform = identity
     end
     return ds
@@ -174,7 +174,7 @@ end
 set_format!(ds::Dataset) = reset_format!(ds)
 
 function reset_format!(ds::Dataset)
-    ds.pyds.set_format(nothing)
+    ds.py.set_format(nothing)
     ds.jltransform = identity
     return ds
 end

--- a/src/datasetdict.jl
+++ b/src/datasetdict.jl
@@ -1,5 +1,5 @@
 """
-    DatasetDict(pyd::Py, jltransform = identity)
+    DatasetDict(py::Py, jltransform = identity)
 
 A `DatasetDict` is a dictionary of `Dataset`s.
 It is a wrapper around a `datasets.DatasetDict` object.
@@ -48,7 +48,7 @@ false
 ```
 """
 mutable struct DatasetDict <: AbstractDict{String, Dataset}
-    pyd::Py
+    py::Py
     jltransform
 
     function DatasetDict(pydatasetdict::Py, jltransform = identity)
@@ -65,7 +65,7 @@ function Base.getproperty(d::DatasetDict, s::Symbol)
     elseif s === :with_format
         return format -> with_format(d, format)
     else
-        res = getproperty(getfield(d, :pyd), s)
+        res = getproperty(getfield(d, :py), s)
         if pycallable(res)
             return CallableWrapper(res)
         else
@@ -74,20 +74,20 @@ function Base.getproperty(d::DatasetDict, s::Symbol)
     end
 end
 
-Base.length(d::DatasetDict) = length(d.pyd)
+Base.length(d::DatasetDict) = length(d.py)
 
 function Base.getindex(d::DatasetDict, i::AbstractString)
-    x = d.pyd[i]
+    x = d.py[i]
     return Dataset(x, d.jltransform)
 end
 
-Base.keys(d::DatasetDict) = String[pyconvert(String, k) for k in d.pyd.keys()]
+Base.keys(d::DatasetDict) = String[pyconvert(String, k) for k in d.py.keys()]
 
 Base.values(d::DatasetDict) = Dataset[d[k] for k in keys(d)]
 
 Base.pairs(d::DatasetDict) = Pair{String,Dataset}[k => d[k] for k in keys(d)]
 
-Base.haskey(d::DatasetDict, k::AbstractString) = pyconvert(Bool, pyin(k, d.pyd))
+Base.haskey(d::DatasetDict, k::AbstractString) = pyconvert(Bool, pyin(k, d.py))
 
 Base.iterate(d::DatasetDict, state...) = iterate(pairs(d), state...)
 
@@ -96,15 +96,15 @@ Base.get(d::DatasetDict, k::AbstractString, default) = haskey(d, k) ? d[k] : def
 # The generic `AbstractDict` `merge`/`filter` build the result with `empty(d)`, which
 # returns a plain `Dict` and drops the wrapper. Override them to return a `DatasetDict`
 # backed by a fresh `datasets.DatasetDict`, preserving `d`'s `jltransform`.
-_pyds(v::Dataset) = getfield(v, :pyds)
-_pyds(v::Py) = v
+_py(v::Dataset) = getfield(v, :py)
+_py(v::Py) = v
 
 function _wrap_pairs(itr, jltransform)
-    pyd = datasets.DatasetDict()
+    py = datasets.DatasetDict()
     for (k, v) in itr
-        pyd[String(k)] = _pyds(v)
+        py[String(k)] = _py(v)
     end
-    return DatasetDict(pyd, jltransform)
+    return DatasetDict(py, jltransform)
 end
 
 Base.filter(f, d::DatasetDict) = _wrap_pairs(Iterators.filter(f, pairs(d)), d.jltransform)
@@ -115,9 +115,9 @@ end
 
 function Base.deepcopy_internal(d::DatasetDict, stackdict::IdDict)
     haskey(stackdict, d) && return stackdict[d]::DatasetDict
-    pyd = pycopy.deepcopy(getfield(d, :pyd))
+    py = pycopy.deepcopy(getfield(d, :py))
     jltransform = Base.deepcopy_internal(getfield(d, :jltransform), stackdict)
-    d2 = DatasetDict(pyd, jltransform)
+    d2 = DatasetDict(py, jltransform)
     stackdict[d] = d2
     return d2
 end
@@ -126,16 +126,16 @@ end
 # but has an independent format, so `set_format!`/`set_jltransform!` on the copy
 # do not affect the original. Used internally by the copy-on-write helpers.
 function Base.copy(d::DatasetDict)
-    pyd = pycopy.copy(getfield(d, :pyd))
-    return DatasetDict(pyd, getfield(d, :jltransform))
+    py = pycopy.copy(getfield(d, :py))
+    return DatasetDict(py, getfield(d, :jltransform))
 end
 
-Base.show(io::IO, ds::DatasetDict) = print(io, ds.pyd)
+Base.show(io::IO, ds::DatasetDict) = print(io, ds.py)
 
 # `DatasetDict` is an `AbstractDict`, so without this method the REPL would use the
 # generic `AbstractDict` multi-line display. Show the Python-style repr instead, which
 # mirrors `datasets.DatasetDict` and nests the `Dataset` summaries.
-Base.show(io::IO, ::MIME"text/plain", ds::DatasetDict) = print(io, ds.pyd)
+Base.show(io::IO, ::MIME"text/plain", ds::DatasetDict) = print(io, ds.py)
 
 """
     with_jltransform(d::DatasetDict, transform)
@@ -190,10 +190,10 @@ version of [`with_format`](@ref).
 """
 function set_format!(d::DatasetDict, format)
     if format == "julia"
-        d.pyd.reset_format()
+        d.py.reset_format()
         d.jltransform = py2jl
     else
-        d.pyd.set_format(format)
+        d.py.set_format(format)
         d.jltransform = identity
     end
     return d
@@ -207,7 +207,7 @@ set_format!(d::DatasetDict) = reset_format!(d)
 Reset the format of `d`, removing any python format and julia transform.
 """
 function reset_format!(d::DatasetDict)
-    d.pyd.set_format(nothing)
+    d.py.set_format(nothing)
     d.jltransform = identity
     return d
 end


### PR DESCRIPTION
## Summary

The two wrappers named their underlying Python handle differently: `Dataset.pyds` vs `DatasetDict.pyd`. This unifies both on `py` (`ds.py`, `dd.py`) and collapses the `_pyds` helper to `_py(v::Dataset) = getfield(v, :py)`.

The field is not part of the public API — both structs override `getproperty` to forward unknown symbols to Python, and the name appears in no docs, examples, or docstring bodies (constructor args are positional). So the rename is non-breaking for documented usage.

## Changes
- `src/dataset.jl`: field `pyds` → `py` (struct, constructor, all `getfield`/`ds.pyds` sites) + stale comment fix.
- `src/datasetdict.jl`: field `pyd` → `py`, docstring signature, and `_pyds` helper → `_py`.
- `CHANGELOG.md`: note under Changed.

## Testing
Package loads and a smoke test (construct → index → wrap into a `DatasetDict` → read keys) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)