### PR TITLE
Collapse `get(::DatasetDict, ...)` to a single Python round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CMYK, palette) return the raw array instead of raising an error.
 - Invalid arguments now raise `ArgumentError`, and out-of-range indices raise
   `BoundsError`, instead of `AssertionError`.
+- `get(::DatasetDict, key, default)` now does a single Python round-trip (via
+  `dict.get`) instead of a separate `haskey` + lookup.
 
 ### Fixed
 - Keyword arguments are correctly forwarded to wrapped Python methods (e.g.

--- a/src/datasetdict.jl
+++ b/src/datasetdict.jl
@@ -91,7 +91,13 @@ Base.haskey(d::DatasetDict, k::AbstractString) = pyconvert(Bool, pyin(k, d.pyd))
 
 Base.iterate(d::DatasetDict, state...) = iterate(pairs(d), state...)
 
-Base.get(d::DatasetDict, k::AbstractString, default) = haskey(d, k) ? d[k] : default
+# Single Python round-trip: `datasets.DatasetDict` subclasses `dict`, so `dict.get`
+# with a `None` sentinel both tests membership and fetches the value at once. Stored
+# values are always `Dataset`s, so `None` unambiguously means "absent".
+function Base.get(d::DatasetDict, k::AbstractString, default)
+    x = d.pyd.get(k, nothing)
+    return pyis(x, pybuiltins.None) ? default : Dataset(x, d.jltransform)
+end
 
 # The generic `AbstractDict` `merge`/`filter` build the result with `empty(d)`, which
 # returns a plain `Dict` and drops the wrapper. Override them to return a `DatasetDict`


### PR DESCRIPTION
## Summary

`get(d::DatasetDict, k, default)` previously called `haskey` (one Python crossing via `pyin`) and then, on a hit, `d[k]` (a second crossing via `d.pyd[i]`). Since `datasets.DatasetDict` subclasses `dict`, `dict.get` with a `None` sentinel collapses this to a single crossing that both tests membership and fetches the value. Stored values are always `Dataset`s, so `None` unambiguously means "absent".

```julia
function Base.get(d::DatasetDict, k::AbstractString, default)
    x = d.pyd.get(k, nothing)
    return pyis(x, pybuiltins.None) ? default : Dataset(x, d.jltransform)
end
```

## Testing
Existing `get` coverage in `test/datasetdict.jl` still holds (hit returns a `Dataset`, miss returns the default). Additionally verified locally: non-`nothing` defaults are returned on miss, and the wrapper's `jltransform` is preserved on the returned `Dataset` (e.g. after `with_format(dd, "julia")`).

Resolves item 4 from the internal review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)