### PR TITLE
Preserve julia format/jltransform through forwarded methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and mutations propagate in both directions.
 - `py2jl` on a Python tuple now returns a proper Julia tuple of converted elements. It
   previously returned a 1-tuple wrapping an unevaluated generator.
+- The `"julia"` format (and any custom `jltransform`) now survives forwarded methods that
+  return a new dataset (`shuffle`, `select`, `sort`, `filter`, `map`, `train_test_split`,
+  …). The parent's transform is propagated onto the result, mirroring how `datasets`
+  propagates Python-side formats; previously it was dropped and the result came back as a
+  raw `Py`.
 
 ## [0.3.4]
 

--- a/src/callable.jl
+++ b/src/callable.jl
@@ -1,8 +1,19 @@
 struct CallableWrapper
     f::Py
+    jltransform          # parent's julia transform, propagated onto returned datasets
 end
 
+CallableWrapper(f::Py) = CallableWrapper(f, identity)
+
 function (cw::CallableWrapper)(args...; kwargs...)
-    y = cw.f(args...; kwargs...)
-    return py2jl(y)
+    y = py2jl(cw.f(args...; kwargs...))
+    # A forwarded method that returns a new dataset (`shuffle`, `select`, `map`, ...) drops
+    # the parent's `jltransform` because `py2jl` re-wraps with the default `identity`.
+    # Re-attach it so the `"julia"` format (and any custom transform) survives the call,
+    # matching how `datasets` propagates Python-side formats. For a real Python format the
+    # transform is `identity`, so this is a no-op and Python's own propagation still governs.
+    if y isa Dataset || y isa DatasetDict
+        return set_jltransform!(y, cw.jltransform)
+    end
+    return y
 end

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -67,7 +67,7 @@ function Base.getproperty(ds::Dataset, s::Symbol)
     else
         res = getproperty(getfield(ds, :py), s)
         if pycallable(res)
-            return CallableWrapper(res)
+            return CallableWrapper(res, getfield(ds, :jltransform))
         else
             return res |> py2jl
         end

--- a/src/datasetdict.jl
+++ b/src/datasetdict.jl
@@ -67,7 +67,7 @@ function Base.getproperty(d::DatasetDict, s::Symbol)
     else
         res = getproperty(getfield(d, :py), s)
         if pycallable(res)
-            return CallableWrapper(res)
+            return CallableWrapper(res, getfield(d, :jltransform))
         else
             return res |> py2jl
         end

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -164,8 +164,35 @@ end
     ds = with_jltransform(mnist) do x
         x = py2jl(x)
         @test x["image"] isa Vector # batch
-        return x 
+        return x
     end
     ds[1]
     ds[1:2]
+end
+
+@testset "julia format survives forwarded methods" begin
+    ds = Dataset(HuggingFaceDatasets.datasets.Dataset.from_dict(
+        pydict(Dict("label" => pylist([5, 0, 4, 3, 2, 1])))))
+    dsj = with_format(ds, "julia")
+
+    # Methods returning a new `Dataset` keep the `"julia"` format (item 3 regression).
+    @test dsj.shuffle(seed=0)[1] isa Dict{String, Int64}
+    @test dsj.select(0:1)[1] isa Dict{String, Int64}
+    @test dsj.filter(@pyeval("lambda x: x['label'] > 2"))[1] isa Dict{String, Int64}
+
+    # ... and so does `train_test_split`, whose result is a `DatasetDict`.
+    split = dsj.train_test_split(test_size=0.5)
+    @test split isa DatasetDict
+    @test split["train"][1] isa Dict{String, Int64}
+
+    # A custom `jltransform` is propagated too.
+    dst = with_jltransform(ds, x -> py2jl(x["label"]) .+ 100)
+    @test dst.shuffle(seed=0)[1:2] isa Vector{Int}
+    @test all(≥(100), dst.select(0:1)[1:2])
+
+    # For a non-"julia" Python format, the transform is `identity`, so re-attaching is a
+    # no-op and Python's own format propagation still governs.
+    dsn = with_format(ds, "numpy")
+    @test getfield(dsn.select(0:1), :jltransform) === identity
+    @test dsn.select(0:1).format["type"] == "numpy"
 end


### PR DESCRIPTION
## Problem

Any forwarded `Dataset`/`DatasetDict` method that returns a new dataset — `shuffle`, `select`, `sort`, `filter`, `map`, `rename_column`, `train_test_split`, … — was routed through `CallableWrapper`, which re-wrapped the result via `py2jl` with the default `jltransform = identity`. The parent's transform was never carried over, so the `"julia"` format silently evaporated across a single chained call:

```julia
julia> dsj = with_format(ds, "julia");
julia> dsj[1]                  # Dict{String,Int64} — julia types ✓
julia> dsj.shuffle(seed=0)[1]  # Py — julia format LOST ✗
```

This is asymmetric with Python-side formats, which `datasets` stores on the Arrow object and propagates itself. It silently defeated the `load_dataset(...).with_format("julia").train_test_split(...)` idiom shown throughout the docs.

## Fix

`CallableWrapper` now carries the parent's `jltransform` and re-attaches it (via `set_jltransform!`) onto any `Dataset`/`DatasetDict` a forwarded method returns; both `getproperty` methods build it as `CallableWrapper(res, getfield(ds, :jltransform))`. For a real Python format the transform is `identity`, so the re-attach is a no-op and Python's own propagation still governs.

## Tests

New testset in `test/dataset.jl` covering `shuffle`/`select`/`filter`/`train_test_split`, a custom `jltransform`, and the numpy no-op case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)