### PR TITLE
Julia-friendly map/filter and public jl2py

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -32,10 +32,18 @@ with_jltransform
 set_jltransform!
 ```
 
+## Transforming
+
+```@docs
+map(f, ::Dataset)
+filter(f, ::Dataset)
+```
+
 ## Type conversion
 
 ```@docs
 py2jl
+jl2py
 numpy2jl
 jl2numpy
 ```

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -254,8 +254,9 @@ julia> ds2[1:3]["label"]
 julia> ds3 = filter(x -> x["label"] > 2, dsj);   # keep rows with label > 2
 
 julia> ds3[:]["label"]
-1-element Vector{Int64}:
+2-element Vector{Int64}:
  5
+ 4
 ```
 
 A few things to note:

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -216,6 +216,63 @@ The order of operations when you index is:
 data with the original but has an independent format, so setting a format or transform on
 the copy does not affect the original.
 
+## Transforming with `map` and `filter`
+
+`map` and `filter` are the core `datasets` verbs for building a new dataset from an
+existing one. Both are available in two flavours.
+
+The **forwarded Python methods** `ds.map(...)` / `ds.filter(...)` (see
+[Method forwarding](@ref) above) behave exactly as in Python: the callback receives raw
+`Py` rows or batches and must return Python-compatible values, so you write it in
+"PythonCall dialect" (`pyconvert` on the way in, `pylist`/`pydict` on the way out):
+
+```julia-repl
+julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4])));
+
+julia> ds.map(x -> pydict(label=pylist([pyconvert(Int, l) + 100 for l in x["label"]])),
+              batched=true);          # written against the Python API
+```
+
+The **Julia-friendly overloads** [`map(f, ds)`](@ref) / [`filter(f, ds)`](@ref) bridge
+the callback for you: each example (or batch, with `batched=true`) is converted with
+[`py2jl`](@ref) before `f` sees it, and `f`'s Julia return value is converted back to
+Python with [`jl2py`](@ref) (the write-path dual of `py2jl`). You can therefore write a
+pure-Julia transform while still getting `datasets`' batching, caching, and
+multiprocessing:
+
+```julia-repl
+julia> dsj = with_format(ds, "julia");
+
+julia> ds2 = map(x -> Dict("label" => x["label"] .+ 100), dsj; batched=true);
+
+julia> ds2[1:3]["label"]
+3-element Vector{Int64}:
+ 105
+ 100
+ 104
+
+julia> ds3 = filter(x -> x["label"] > 2, dsj);   # keep rows with label > 2
+
+julia> ds3[:]["label"]
+1-element Vector{Int64}:
+ 5
+```
+
+A few things to note:
+
+- **Batched or not.** Without `batched=true` the callback sees one example at a time (a
+  `Dict` of scalar values, or whatever `py2jl` returns); with `batched=true` it sees a
+  batch (a `Dict` mapping each column to a vector). Return the same shape: a scalar
+  (`map`) / `Bool` (`filter`) per example, or a vector per column / `Vector{Bool}` when
+  batched.
+- **Keyword arguments** such as `batched`, `num_proc`, and `remove_columns` are forwarded
+  to the Python method, so multiprocessing and caching work as usual.
+- **Format is preserved.** The returned `Dataset` inherits the parent's `"julia"` format
+  (or any custom `jltransform`), so `ds2` above is still `"julia"`-formatted and a chained
+  pipeline like `map(f, dsj) |> ...` keeps returning Julia values.
+- **Reach for the Python method** with `ds.map(...)` whenever you specifically want to
+  hand `map`/`filter` a raw Python callback instead.
+
 ## Array and image orientation
 
 !!! warning "Arrays come back transposed"

--- a/src/HuggingFaceDatasets.jl
+++ b/src/HuggingFaceDatasets.jl
@@ -31,8 +31,9 @@ export DatasetDict
 include("column.jl")
 
 include("transforms.jl")
-export py2jl, 
-    jl2numpy, 
+export py2jl,
+    jl2py,
+    jl2numpy,
     numpy2jl
 
 include("load_dataset.jl")

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -105,6 +105,62 @@ function Base.getindex(ds::Dataset, i::AbstractString)
     return ds.jltransform(d)[i]
 end
 
+"""
+    map(f, ds::Dataset; kws...)
+
+Apply `f` to `ds` through `datasets`' `map`, bridging Julia values on both sides: each
+example (or batch, with `batched=true`) is converted with [`py2jl`](@ref) before `f` sees
+it, and `f`'s return value is converted back to Python with [`jl2py`](@ref). This lets you
+write pure-Julia transforms while still getting `datasets`' batching, caching, and
+multiprocessing.
+
+Keyword arguments (`batched`, `num_proc`, `remove_columns`, ...) are forwarded to the
+Python `map`. The parent's julia format/transform is preserved on the returned `Dataset`.
+
+Use `ds.map(...)` (the forwarded Python method) if you need to hand `map` a raw Python
+callback instead.
+
+See also [`filter`](@ref).
+
+# Examples
+
+```julia
+julia> ds = with_format(Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4]))), "julia");
+
+julia> ds2 = map(x -> Dict("label" => x["label"] .+ 100), ds; batched=true);
+
+julia> ds2[1:3]["label"]
+3-element Vector{Int64}:
+ 105
+ 100
+ 104
+```
+"""
+function Base.map(f, ds::Dataset; kws...)
+    g = x -> jl2py(f(py2jl(x)))
+    y = getfield(ds, :py).map(g; kws...)
+    return Dataset(y, getfield(ds, :jltransform))
+end
+
+"""
+    filter(f, ds::Dataset; kws...)
+
+Filter `ds` through `datasets`' `filter`, bridging Julia values: each example (or batch,
+with `batched=true`) is converted with [`py2jl`](@ref) before `f` sees it, and `f` returns
+a `Bool` (or, when `batched=true`, a `Vector{Bool}`), converted back to Python with
+[`jl2py`](@ref).
+
+Keyword arguments are forwarded to the Python `filter`; the parent's julia format/transform
+is preserved on the returned `Dataset`.
+
+See also [`map`](@ref).
+"""
+function Base.filter(f, ds::Dataset; kws...)
+    g = x -> jl2py(f(py2jl(x)))
+    y = getfield(ds, :py).filter(g; kws...)
+    return Dataset(y, getfield(ds, :jltransform))
+end
+
 function Base.deepcopy_internal(ds::Dataset, stackdict::IdDict)
     haskey(stackdict, ds) && return stackdict[ds]::Dataset
     py = pycopy.deepcopy(getfield(ds, :py))

--- a/src/datasetdict.jl
+++ b/src/datasetdict.jl
@@ -95,7 +95,7 @@ Base.iterate(d::DatasetDict, state...) = iterate(pairs(d), state...)
 # with a `None` sentinel both tests membership and fetches the value at once. Stored
 # values are always `Dataset`s, so `None` unambiguously means "absent".
 function Base.get(d::DatasetDict, k::AbstractString, default)
-    x = d.pyd.get(k, nothing)
+    x = d.py.get(k, nothing)
     return pyis(x, pybuiltins.None) ? default : Dataset(x, d.jltransform)
 end
 

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -124,3 +124,50 @@ function jl2numpy(x::AbstractArray)
     # read-only, which would break the documented write-back behaviour.)
     return np.asarray(Py(x)).T
 end
+
+"""
+    jl2py(x)
+
+Convert Julia values to Python, the inverse of [`py2jl`](@ref). Recursively traverses
+`AbstractDict`, `NamedTuple`, `Tuple`, and `AbstractVector` containers, converting the
+leaves. Multi-dimensional numeric `AbstractArray`s are converted with [`jl2numpy`](@ref)
+(copyless, with the documented axis reversal); other leaves are handed to PythonCall's
+default `Py` conversion.
+
+This is the write-path dual of `py2jl`, used to bridge pure-Julia callbacks into the
+Python `datasets` API (see the Julia-friendly [`map`](@ref) / [`filter`](@ref) overloads).
+
+# Examples
+
+```jldoctest
+julia> jl2py(Dict("label" => [1, 2, 3]))
+Python: {'label': [1, 2, 3]}
+
+julia> jl2py((1, "a", [2, 3]))
+Python: (1, 'a', [2, 3])
+```
+"""
+jl2py(x) = Py(x)
+jl2py(x::Py) = x
+
+function jl2py(x::AbstractDict)
+    d = pydict()
+    for (k, v) in x
+        d[jl2py(k)] = jl2py(v)
+    end
+    return d
+end
+
+function jl2py(x::NamedTuple)
+    d = pydict()
+    for k in keys(x)
+        d[string(k)] = jl2py(x[k])
+    end
+    return d
+end
+
+jl2py(x::Tuple) = pytuple(Tuple(jl2py(el) for el in x))
+jl2py(x::AbstractVector) = pylist(jl2py(el) for el in x)
+# N-D (N ≥ 2) numeric arrays go through the copyless numpy view; vectors are handled
+# element-wise above so a `Vector` of arrays becomes a Python list of numpy arrays.
+jl2py(x::AbstractArray) = jl2numpy(x)

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -196,3 +196,28 @@ end
     @test getfield(dsn.select(0:1), :jltransform) === identity
     @test dsn.select(0:1).format["type"] == "numpy"
 end
+
+@testset "julia-friendly map / filter" begin
+    ds = Dataset(HuggingFaceDatasets.datasets.Dataset.from_dict(
+        pydict(Dict("label" => pylist([5, 0, 4, 3, 2, 1])))))
+    dsj = with_format(ds, "julia")
+
+    # `map` bridges Julia values on both sides: pure-Julia callback, no PythonCall dialect.
+    ds2 = map(x -> Dict("label" => x["label"] .+ 100), dsj; batched=true)
+    @test ds2 isa Dataset
+    @test ds2[1:6]["label"] == [105, 100, 104, 103, 102, 101]  # julia format preserved
+
+    # non-batched map (one example at a time)
+    ds3 = map(x -> Dict("label" => x["label"] + 1), dsj)
+    @test ds3[1:6]["label"] == [6, 1, 5, 4, 3, 2]
+
+    # `filter` with a Julia predicate returning a Bool
+    ds4 = filter(x -> x["label"] > 2, dsj)
+    @test ds4 isa Dataset
+    @test sort(ds4[1:length(ds4)]["label"]) == [3, 4, 5]
+
+    # batched filter returning a Vector{Bool}, and format preservation
+    ds5 = filter(x -> x["label"] .< 3, dsj; batched=true)
+    @test ds5[1] isa Dict{String, Int64}
+    @test sort(ds5[1:length(ds5)]["label"]) == [0, 1, 2]
+end

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -27,6 +27,30 @@
     @test collect(col) == [5, 0, 4]
 end
 
+@testset "jl2py" begin
+    # scalars fall back to PythonCall's default conversion
+    @test pyconvert(Int, jl2py(3)) == 3
+    @test pyconvert(String, jl2py("a")) == "a"
+
+    # a Py passes through unchanged
+    p = pylist([1, 2])
+    @test jl2py(p) === p
+
+    # vectors -> python lists (element-wise), dicts/namedtuples -> python dicts
+    @test pyisinstance(jl2py([1, 2, 3]), pytype(pylist()))
+    @test py2jl(jl2py(Dict("a" => [1, 2], "b" => [3, 4]))) == Dict("a" => [1, 2], "b" => [3, 4])
+    @test py2jl(jl2py((label = [1, 2], x = [3, 4]))) == Dict("label" => [1, 2], "x" => [3, 4])
+    @test py2jl(jl2py((1, "a", [2, 3]))) == (1, "a", [2, 3])
+
+    # N-D numeric arrays go through jl2numpy (axis-reversed, round-trips via py2jl)
+    x = Float32[1 2 3; 4 5 6]
+    @test py2jl(jl2py(x)) == x
+
+    # a vector of arrays becomes a python list of numpy arrays
+    v = [Int[1, 2], Int[3, 4]]
+    @test py2jl(jl2py(v)) == v
+end
+
 @testset "jl2numpy / numpy2jl" begin
     # round-trip across dtypes and dimensionalities (dims are permuted then permuted back)
     for x in Any[Float32[1 2; 3 4], Int64[1, 2, 3, 4], rand(UInt8, 2, 3, 4)]


### PR DESCRIPTION
Resolves item 4 of the review: `map`/`filter` callbacks were Python-in / Python-out.

`map` is *the* core `datasets` verb, but a Julia function handed to it was neither given Julia inputs nor allowed to return Julia outputs — the callback received raw `Py` rows/batches, and a Julia `Vector` return was rejected by `datasets`' `validate_function_output`. So every transform had to be written in "PythonCall dialect" (`pyconvert` in, `pylist`/`pydict` out) — exactly the leakage the `"julia"` format removes on the read path, reappearing on the transform path.

## Changes

- **New public `jl2py(x)`** (`src/transforms.jl`) — the write-path dual of `py2jl`. Recursively converts `AbstractDict`/`NamedTuple` → Python dict, `Tuple` → tuple, `AbstractVector` → list (element-wise, so a `Vector` of arrays becomes a list of numpy arrays), N-D numeric arrays → `jl2numpy` (copyless, axis-reversed), scalars → PythonCall's default. Exported.
- **`Base.map(f, ds::Dataset; kws...)` / `Base.filter(f, ds::Dataset; kws...)`** (`src/dataset.jl`) — install `x -> jl2py(f(py2jl(x)))` as the Python callback, so users write pure-Julia transforms while still getting `datasets`' batching/caching/multiprocessing. Keyword args (`batched`, `num_proc`, `remove_columns`, …) are forwarded, and the parent's julia format/transform is preserved on the returned `Dataset` (composes with #52). `ds.map(...)` still reaches the raw Python-callback method for anyone who wants it.
- **Tests** — "jl2py" (`test/transforms.jl`) and "julia-friendly map / filter" (`test/dataset.jl`), covering batched/non-batched map and filter (`Bool` and `Vector{Bool}` returns) plus format preservation.
- **Docs** — `jl2py` and a "Transforming" section for `map`/`filter` added to `docs/src/api.md`.

## Verification

- New testsets pass; `transforms` suite 31/31.
- Doctests pass and full `makedocs` builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)