### PR TITLE
Support constructing a Dataset from Julia data

### DIFF
--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -11,8 +11,9 @@ This guide covers how the wrapper relates to the underlying Python `datasets` li
 the `"julia"` format and the transform pipeline, the array/image orientation caveat, and
 how to feed a dataset into a Julia data loader.
 
-The examples below build small datasets in memory with
-`datasets.Dataset.from_dict` so that they are self-contained and reproducible. In
+The examples below build small datasets in memory with the [`Dataset`](@ref) constructor
+(which accepts a `Dict` or `NamedTuple` of columns) so that they are self-contained and
+reproducible. In
 practice you will usually obtain a dataset from the Hub with [`load_dataset`](@ref), e.g.
 `load_dataset("ylecun/mnist", split="train")`; everything shown here applies equally to
 those datasets.
@@ -32,11 +33,11 @@ A [`DatasetDict`](@ref) is an `AbstractDict{String, Dataset}`, so `keys`, `value
 `haskey`, `get`, and iteration all work as expected:
 
 ```jldoctest guide
-julia> train = datasets.Dataset.from_dict(pydict(label=[1, 0, 1, 0]));
+julia> train = Dataset((; label=[1, 0, 1, 0]));
 
-julia> test = datasets.Dataset.from_dict(pydict(label=[1, 1]));
+julia> test = Dataset((; label=[1, 1]));
 
-julia> dd = DatasetDict(datasets.DatasetDict(pydict(; train, test)))
+julia> dd = DatasetDict(datasets.DatasetDict(pydict(train=train.py, test=test.py)))
 DatasetDict({
     train: Dataset({
         features: ['label'],
@@ -64,7 +65,7 @@ A [`Dataset`](@ref) supports 1-based indexing, `length`, `firstindex`/`lastindex
 (so `ds[begin]` and `ds[end]` work), and iteration over observations:
 
 ```jldoctest guide
-julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4])));
+julia> ds = Dataset((; label=[5, 0, 4]));
 
 julia> length(ds)
 3
@@ -94,7 +95,7 @@ wrapper. Method calls are forwarded to Python, and their results are converted b
 binding for each method:
 
 ```jldoctest guide
-julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[0, 1, 2, 3])));
+julia> ds = Dataset((; label=[0, 1, 2, 3]));
 
 julia> ds.select(0:1)                       # keep the first two rows
 Dataset({
@@ -137,7 +138,7 @@ Julia-side transform.
 [`set_format!`](@ref) mutates it in place; [`reset_format!`](@ref) clears it.
 
 ```jldoctest guide
-julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4])));
+julia> ds = Dataset((; label=[5, 0, 4]));
 
 julia> ds[1]
 Python: {'label': 5}
@@ -177,7 +178,7 @@ raw Python batch, so convert it with [`py2jl`](@ref) first if you want to work w
 types:
 
 ```jldoctest guide
-julia> ds = Dataset(datasets.Dataset.from_dict(pydict(x=[1, 2, 3])));
+julia> ds = Dataset((; x=[1, 2, 3]));
 
 julia> ds = with_jltransform(ds) do batch
            b = py2jl(batch)          # convert the Python batch to Julia types first
@@ -227,7 +228,7 @@ The **forwarded Python methods** `ds.map(...)` / `ds.filter(...)` (see
 "PythonCall dialect" (`pyconvert` on the way in, `pylist`/`pydict` on the way out):
 
 ```julia-repl
-julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4])));
+julia> ds = Dataset((; label=[5, 0, 4]));
 
 julia> ds.map(x -> pydict(label=pylist([pyconvert(Int, l) + 100 for l in x["label"]])),
               batched=true);          # written against the Python API
@@ -318,7 +319,7 @@ data loaders such as `Flux.DataLoader` work directly:
 ```jldoctest guide
 julia> using MLUtils
 
-julia> ds = Dataset(datasets.Dataset.from_dict(pydict(x=[1, 2, 3, 4]))).with_format("julia");
+julia> ds = Dataset((; x=[1, 2, 3, 4])).with_format("julia");
 
 julia> numobs(ds)
 4

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -63,7 +63,7 @@ memory so it is reproducible, but the same applies to any dataset from the Hub:
 ```jldoctest
 julia> using HuggingFaceDatasets, PythonCall
 
-julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4])));
+julia> ds = Dataset((; label=[5, 0, 4]));
 
 julia> ds[1]                            # a Python object by default
 Python: {'label': 5}

--- a/src/column.jl
+++ b/src/column.jl
@@ -17,7 +17,7 @@ of a julia-formatted [`Dataset`], e.g. `ds["label"]`.
 # Examples
 
 ```jldoctest
-julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4])));
+julia> ds = Dataset((; label=[5, 0, 4]));
 
 julia> ds = with_format(ds, "julia");
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -15,7 +15,7 @@ See also [`load_dataset`](@ref), [`DatasetDict`](@ref), and [`with_format`](@ref
 # Examples
 
 ```jldoctest
-julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4])))
+julia> ds = Dataset((; label=[5, 0, 4]))
 Dataset({
     features: ['label'],
     num_rows: 3
@@ -175,7 +175,7 @@ See also [`filter`](@ref).
 # Examples
 
 ```julia
-julia> ds = with_format(Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4]))), "julia");
+julia> ds = with_format(Dataset((; label=[5, 0, 4])), "julia");
 
 julia> ds2 = map(x -> Dict("label" => x["label"] .+ 100), ds; batched=true);
 
@@ -243,7 +243,7 @@ See also [`set_format!`](@ref).
 # Examples
 
 ```jldoctest
-julia> ds = Dataset(datasets.Dataset.from_dict(pydict(label=[5, 0, 4])));
+julia> ds = Dataset((; label=[5, 0, 4]));
 
 julia> ds[1]
 Python: {'label': 5}

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -53,11 +53,61 @@ mutable struct Dataset
     end
 end
 
-## TODO make it work with arbitrary order tensors
-# function Dataset(d::Dict; jltransform = identity)
-#     py = datasets.Dataset.from_dict(d)
-#     return Dataset(py, jltransform)
-# end
+"""
+    Dataset(d::AbstractDict; jltransform = identity)
+    Dataset(nt::NamedTuple; jltransform = identity)
+
+Build a `Dataset` from in-memory Julia data: a `Dict` or `NamedTuple` mapping column
+names to equal-length vectors, delegating to `datasets.Dataset.from_dict`.
+
+Only **scalar-element** columns are supported for now (numbers, strings, booleans, ...).
+Array-valued columns (e.g. a `Vector{Matrix}` image column) are rejected with an
+`ArgumentError` rather than silently transposed, since Julia is column-major while Arrow
+and numpy are row-major. Build those with `datasets.Dataset.from_dict` directly for now.
+
+See also [`with_format`](@ref) and [`jl2py`](@ref).
+
+# Examples
+
+```jldoctest
+julia> ds = Dataset((label = [5, 0, 4], text = ["a", "b", "c"]))
+Dataset({
+    features: ['label', 'text'],
+    num_rows: 3
+})
+
+julia> with_format(ds, "julia")[1:3]["label"]
+3-element Vector{Int64}:
+ 5
+ 0
+ 4
+```
+"""
+Dataset(d::AbstractDict; jltransform = identity) =
+    Dataset(datasets.Dataset.from_dict(_from_dict_pydict(d)), jltransform)
+
+Dataset(nt::NamedTuple; jltransform = identity) =
+    Dataset(datasets.Dataset.from_dict(_from_dict_pydict(nt)), jltransform)
+
+# Convert a Julia column mapping (Dict/NamedTuple of vectors) into a Python dict suitable
+# for `datasets.Dataset.from_dict`, rejecting array-valued (multi-dimensional) columns.
+function _from_dict_pydict(d)
+    py = pydict()
+    for (k, v) in pairs(d)
+        v isa AbstractVector || throw(ArgumentError(
+            "column \"$k\" must be an AbstractVector of scalars, got $(typeof(v))"))
+        et = eltype(v)
+        if et <: AbstractArray || (!isconcretetype(et) && any(x -> x isa AbstractArray, v))
+            throw(ArgumentError(
+                "column \"$k\" has array-valued elements; constructing a Dataset from " *
+                "multi-dimensional columns is not yet supported (elements would be " *
+                "silently transposed). Build it with `datasets.Dataset.from_dict` " *
+                "directly for now."))
+        end
+        py[string(k)] = jl2py(v)   # scalar vector -> python list
+    end
+    return py
+end
 
 function Base.getproperty(ds::Dataset, s::Symbol)
     if s in fieldnames(Dataset)

--- a/src/datasetdict.jl
+++ b/src/datasetdict.jl
@@ -16,11 +16,11 @@ See also [`load_dataset`](@ref) and [`Dataset`](@ref).
 # Examples
 
 ```jldoctest
-julia> train = datasets.Dataset.from_dict(pydict(label=[1, 0, 1, 0]));
+julia> train = Dataset((; label=[1, 0, 1, 0]));
 
-julia> test = datasets.Dataset.from_dict(pydict(label=[1, 1]));
+julia> test = Dataset((; label=[1, 1]));
 
-julia> dd = DatasetDict(datasets.DatasetDict(pydict(; train, test)))
+julia> dd = DatasetDict(datasets.DatasetDict(pydict(train=train.py, test=test.py)))
 DatasetDict({
     train: Dataset({
         features: ['label'],

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -29,6 +29,42 @@ end
     @test length(collect(ds)) == 3
 end
 
+@testset "construct from Julia data" begin
+    # Dict of scalar vectors round-trips through the julia format
+    ds = Dataset(Dict("label" => [5, 0, 4]))
+    @test ds isa Dataset
+    @test length(ds) == 3
+    @test collect(keys(pyconvert(Dict, ds.py.features))) == ["label"]
+    @test with_format(ds, "julia")[1:3]["label"] == [5, 0, 4]
+
+    # NamedTuple path preserves column names and order
+    ds = Dataset((label = [5, 0, 4], text = ["a", "b", "c"]))
+    @test length(ds) == 3
+    @test ds.column_names == ["label", "text"]
+    dsj = with_format(ds, "julia")
+    @test dsj[1:3]["label"] == [5, 0, 4]
+    @test dsj[1:3]["text"] == ["a", "b", "c"]
+
+    # mixed scalar types each round-trip
+    ds = with_format(Dataset((
+        i = [1, 2], s = ["x", "y"], f = [1.5, 2.5], b = [true, false])), "julia")
+    @test ds[1:2]["i"] == [1, 2]
+    @test ds[1:2]["s"] == ["x", "y"]
+    @test ds[1:2]["f"] == [1.5, 2.5]
+    @test ds[1:2]["b"] == [true, false]
+
+    # jltransform kwarg is applied
+    ds = Dataset(Dict("label" => [5, 0, 4]); jltransform = py2jl)
+    @test ds[1] isa Dict
+    @test ds[1]["label"] == 5
+
+    # array-valued (multi-dim) columns are rejected loudly, not transposed
+    @test_throws ArgumentError Dataset(Dict("x" => [[1, 2], [3, 4]]))
+    @test_throws ArgumentError Dataset(Dict("x" => [rand(2, 2)]))
+    # non-vector columns are rejected
+    @test_throws ArgumentError Dataset(Dict("x" => 5))
+end
+
 @testset "keyword arguments are forwarded to python methods" begin
     # `train_test_split` requires the `test_size` keyword: regression test for the
     # kwargs-forwarding bug where keywords were splatted as positional arguments.


### PR DESCRIPTION
## Summary

Adds a way to build a `Dataset` directly from in-memory Julia data, replacing the long-standing commented-out `# function Dataset(d::Dict; ...)` stub in `src/dataset.jl`. Until now the only way to obtain a `Dataset` was to wrap something the Hub (or a raw `datasets.*` call) already produced, forcing tests, examples, and doctests to drop down to `datasets.Dataset.from_dict(pydict(...))` — the Python-leaking boilerplate the wrapper exists to hide.

New constructors:

```julia
Dataset(d::AbstractDict; jltransform = identity)
Dataset(nt::NamedTuple;  jltransform = identity)
```

Both map column names → equal-length vectors and delegate to `datasets.Dataset.from_dict`.

```julia
ds = Dataset((label = [5, 0, 4], text = ["a", "b", "c"]))
with_format(ds, "julia")[1:3]["label"]   # => [5, 0, 4]
```

## Scope (minimum-viable, per the review)

- **Scalar-element columns only.** Array-valued (multi-dimensional) columns are rejected with an explanatory `ArgumentError` rather than silently transposed, since Julia is column-major while Arrow/numpy are row-major. Tensor-aware columns and Tables.jl ingestion are deliberately deferred.
- Per-column conversion reuses the existing `jl2py` write path, keeping construction symmetric with the read path.
- The `eltype` fast-path keeps the common concrete-scalar case O(1); the element scan only runs for abstract eltypes (e.g. `Vector{Any}`).

## Tests

New offline `@testset "construct from Julia data"` (17 assertions): Dict + NamedTuple round-trips, mixed scalar types, the `jltransform` kwarg, and rejection of vector-of-vector / vector-of-matrix / non-vector columns.

## Verification

- New testset: 17/17 pass.
- Doctests pass (`doctest(HuggingFaceDatasets)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)