### PR TITLE
Python-style interface via getproperty + fix DatasetDict completion segfault

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -37,6 +37,8 @@ set_jltransform!
 ```@docs
 map(f, ::Dataset)
 filter(f, ::Dataset)
+map(f, ::DatasetDict)
+filter(f, ::DatasetDict)
 ```
 
 ## Type conversion

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -225,29 +225,17 @@ the copy does not affect the original.
 ## Transforming with `map` and `filter`
 
 `map` and `filter` are the core `datasets` verbs for building a new dataset from an
-existing one. Both are available in two flavours.
-
-The **forwarded Python methods** `ds.map(...)` / `ds.filter(...)` (see
-[Method forwarding](@ref) above) behave exactly as in Python: the callback receives raw
-`Py` rows or batches and must return Python-compatible values, so you write it in
-"PythonCall dialect" (`pyconvert` on the way in, `pylist`/`pydict` on the way out):
-
-```julia-repl
-julia> ds = Dataset((; label=[5, 0, 4]));
-
-julia> ds.map(x -> pydict(label=pylist([pyconvert(Int, l) + 100 for l in x["label"]])),
-              batched=true);          # written against the Python API
-```
-
-The **Julia-friendly overloads** [`map(f, ds)`](@ref) / [`filter(f, ds)`](@ref) bridge
-the callback for you: each example (or batch, with `batched=true`) is converted with
+existing one. The overloads [`map(f, ds)`](@ref) / [`filter(f, ds)`](@ref) bridge the
+callback for you: each example (or batch, with `batched=true`) is converted with
 [`py2jl`](@ref) before `f` sees it, and `f`'s Julia return value is converted back to
 Python with [`jl2py`](@ref) (the write-path dual of `py2jl`). You can therefore write a
 pure-Julia transform while still getting `datasets`' batching, caching, and
 multiprocessing:
 
 ```julia-repl
-julia> ds2 = map(x -> Dict("label" => x["label"] .+ 100), ds; batched=true);   # ds is julia-formatted
+julia> ds = Dataset((; label=[5, 0, 4]));
+
+julia> ds2 = map(x -> Dict("label" => x["label"] .+ 100), ds; batched=true);
 
 julia> ds2[1:3]["label"]
 3-element Vector{Int64}:
@@ -263,6 +251,12 @@ julia> ds3[:]["label"]
  4
 ```
 
+The property-style calls `ds.map(f)` / `ds.filter(f)` are **equivalent** to `map(f, ds)` /
+`filter(f, ds)` — they route to these same overloads, so the callback still sees Julia values.
+A [`DatasetDict`](@ref) behaves the same way: `map(f, dd)` / `dd.map(f)` and `filter(f, dd)` /
+`dd.filter(f)` apply `f` per example across every split (note this makes `filter(f, dd)` filter
+*examples*, not split entries).
+
 A few things to note:
 
 - **Batched or not.** Without `batched=true` the callback sees one example at a time (a
@@ -275,8 +269,14 @@ A few things to note:
 - **Format is preserved.** The returned `Dataset` inherits the parent's `"julia"` format
   (or any custom `jltransform`), so `ds2` above is still `"julia"`-formatted and a chained
   pipeline like `map(f, dsj) |> ...` keeps returning Julia values.
-- **Reach for the Python method** with `ds.map(...)` whenever you specifically want to
-  hand `map`/`filter` a raw Python callback instead.
+- **Raw Python callbacks.** To hand `map`/`filter` a callback written in "PythonCall
+  dialect" (receiving raw `Py` rows/batches, `pyconvert` in, `pylist`/`pydict` out), reach
+  for the underlying Python method with `ds.py.map(...)` / `ds.py.filter(...)`:
+
+  ```julia-repl
+  julia> ds.py.map(x -> pydict(label=pylist([pyconvert(Int, l) + 100 for l in x["label"]])),
+                   batched=true);      # written against the Python API
+  ```
 
 ## Array orientation
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -146,19 +146,66 @@ end
 _column_to_py(k::AbstractString, v) = throw(ArgumentError(
     "column \"$k\" must be an AbstractArray of observations, got $(typeof(v))"))
 
+# Property names on a `Dataset` routed to this package's own methods instead of being forwarded
+# to the wrapped Python object, so the Python-style calls stay Julian: the format methods
+# understand the `"julia"` pseudo-format, and `map`/`filter` bridge Julia values through
+# `py2jl`/`jl2py` (i.e. `ds.map(f)` is `map(f, ds)`). Returns a callable bound to `ds`, or
+# `nothing` when `s` is not one of these (the caller then forwards to Python). To hand
+# `map`/`filter` a raw Python callback, use the underlying `ds.py.map(...)`/`ds.py.filter(...)`.
+function _method_override(ds::Dataset, s::Symbol)
+    if s === :with_format
+        return (args...; kws...) -> with_format(ds, args...; kws...)
+    elseif s === :set_format
+        return (args...; kws...) -> set_format!(ds, args...; kws...)
+    elseif s === :reset_format
+        return (args...; kws...) -> reset_format!(ds, args...; kws...)
+    elseif s === :map
+        return (f; kws...) -> map(f, ds; kws...)
+    elseif s === :filter
+        return (f; kws...) -> filter(f, ds; kws...)
+    else
+        return nothing
+    end
+end
+
 function Base.getproperty(ds::Dataset, s::Symbol)
     if s in fieldnames(Dataset)
         return getfield(ds, s)
-    elseif s === :with_format
-        return format -> with_format(ds, format)
-    else
-        res = getproperty(getfield(ds, :py), s)
-        if pycallable(res)
-            return CallableWrapper(res, getfield(ds, :jltransform))
-        else
-            return res |> py2jl
-        end
     end
+    # Route the format and `map`/`filter` methods to this package's own versions (see
+    # `_method_override`); every other name forwards to the wrapped Python object.
+    override = _method_override(ds, s)
+    override === nothing || return override
+    res = getproperty(getfield(ds, :py), s)
+    if pycallable(res)
+        return CallableWrapper(res, getfield(ds, :jltransform))
+    else
+        return res |> py2jl
+    end
+end
+
+# Expose the `from_dict` constructor under its Python name, so `Dataset.from_dict(data; ...)`
+# mirrors `datasets.Dataset.from_dict`. `getproperty` is overloaded on the *type* object
+# itself; every name other than `from_dict` falls back to normal `DataType` field access
+# (`Dataset.name`, `Dataset.parameters`, ...), so type introspection is unaffected.
+function Base.getproperty(::Type{Dataset}, s::Symbol)
+    if s === :from_dict
+        return (data; kws...) -> _from_dict(data; kws...)
+    else
+        return getfield(Dataset, s)
+    end
+end
+
+# `Dataset.from_dict` implementation. A Julia `AbstractDict`/`NamedTuple` is turned into a
+# column mapping with the same orientation-aware logic as the `Dataset(data)` constructor
+# (scalar columns and last-axis-stacked N-D array columns); anything else (e.g. a raw Python
+# mapping) is converted with `jl2py`. Extra keyword arguments (`features`, `split`, ...) are
+# forwarded to the Python classmethod. The result is returned in the default `"julia"` format,
+# like the other construction entry points. For the raw Python behavior (first-axis rows, no
+# forced format) call `datasets.Dataset.from_dict(...)` directly.
+function _from_dict(data; kws...)
+    py = data isa Union{AbstractDict,NamedTuple} ? _from_dict_pydict(data) : jl2py(data)
+    return set_format!(Dataset(datasets.Dataset.from_dict(py; kws...)), "julia")
 end
 
 Base.length(ds::Dataset) = length(ds.py)
@@ -204,8 +251,9 @@ multiprocessing.
 Keyword arguments (`batched`, `num_proc`, `remove_columns`, ...) are forwarded to the
 Python `map`. The parent's julia format/transform is preserved on the returned `Dataset`.
 
-Use `ds.map(...)` (the forwarded Python method) if you need to hand `map` a raw Python
-callback instead.
+`ds.map(f; ...)` is equivalent to this `map(f, ds; ...)` (the property call routes here, not
+to Python). If you need to hand `map` a raw Python callback instead, use the underlying
+`ds.py.map(...)`.
 
 See also [`filter`](@ref).
 
@@ -239,6 +287,9 @@ a `Bool` (or, when `batched=true`, a `Vector{Bool}`), converted back to Python w
 
 Keyword arguments are forwarded to the Python `filter`; the parent's julia format/transform
 is preserved on the returned `Dataset`.
+
+`ds.filter(f; ...)` is equivalent to this `filter(f, ds; ...)`; use the underlying
+`ds.py.filter(...)` for a raw Python callback.
 
 See also [`map`](@ref).
 """

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -56,6 +56,7 @@ end
 """
     Dataset(d::AbstractDict; jltransform = nothing)
     Dataset(nt::NamedTuple; jltransform = nothing)
+    Dataset.from_dict(data; features = nothing, split = nothing)
 
 Build a `Dataset` from in-memory Julia data: a `Dict` or `NamedTuple` mapping column
 names to columns, delegating to `datasets.Dataset.from_dict`.
@@ -74,6 +75,12 @@ and a range index stacks rows into a `(dims…, N)` tensor.
 The dataset is returned in the `"julia"` format by default (observations converted to
 native Julia types on access). Pass a `jltransform` to install a custom transform instead,
 or call [`reset_format!`](@ref) for the raw Python observations.
+
+`Dataset.from_dict(data; kws...)` is the same construction exposed under the Python
+classmethod name (`datasets.Dataset.from_dict`): it accepts the same Julia `data` as above —
+and also a raw Python mapping — forwards keyword arguments such as `features` and `split` to
+Python, and likewise defaults to the `"julia"` format. For plain in-memory columns,
+`Dataset.from_dict(data)` is equivalent to `Dataset(data)`.
 
 See also [`with_format`](@ref), [`jl2py`](@ref), and [`jl2numpy`](@ref).
 
@@ -103,6 +110,12 @@ julia> ds[1:3]["x"]         # a range stacks observations along the last axis
 2×3 Matrix{Int64}:
  1  2  3
  4  5  6
+
+julia> Dataset.from_dict(Dict("label" => [5, 0, 4]))   # Python classmethod name; == Dataset(...)
+Dataset({
+    features: ['label'],
+    num_rows: 3
+})
 ```
 """
 Dataset(d::AbstractDict; jltransform = nothing) =

--- a/src/datasetdict.jl
+++ b/src/datasetdict.jl
@@ -60,21 +60,30 @@ false
 mutable struct DatasetDict <: AbstractDict{String, Dataset}
     py::Py
     jltransform::Dict{String, Any}   # per-split julia transforms, one entry per split
+    # Cached, ordered split names. `keys`/`length`/iteration read this instead of calling into
+    # Python, so they stay allocation-cheap AND safe to call from contexts where a Python call
+    # would crash — notably the REPL's async tab-completion (`d[<TAB>` calls `keys`/`length` on
+    # a task where invoking libpython segfaults). Splits are immutable for a `DatasetDict`
+    # (methods that change them return a freshly-wrapped one), so the cache never goes stale.
+    splits::Vector{String}
 
     function DatasetDict(pydatasetdict::Py, jltransform = identity)
         if !pyisinstance(pydatasetdict, datasets.DatasetDict)
             throw(ArgumentError("expected a `datasets.DatasetDict`, got $(pytype(pydatasetdict))"))
         end
-        return new(pydatasetdict, _jltransform_dict(pydatasetdict, jltransform))
+        splits = _split_names(pydatasetdict)
+        return new(pydatasetdict, _jltransform_dict(splits, jltransform), splits)
     end
 end
 
-# Normalize a transform specification into a per-split `Dict` with one entry per split of
-# `py`. A `nothing`/callable spec is broadcast to every split (`nothing` -> `identity`); an
-# `AbstractDict` spec is applied per split (keys stringified), with any split it omits
-# defaulting to `identity`.
-function _jltransform_dict(py::Py, spec)
-    ks = String[pyconvert(String, k) for k in py.keys()]
+# Ordered split names of a `datasets.DatasetDict`, read from Python.
+_split_names(py::Py) = String[pyconvert(String, k) for k in py.keys()]
+
+# Normalize a transform specification into a per-split `Dict` with one entry per split (given
+# by the split names `ks`). A `nothing`/callable spec is broadcast to every split (`nothing`
+# -> `identity`); an `AbstractDict` spec is applied per split (keys stringified), with any
+# split it omits defaulting to `identity`.
+function _jltransform_dict(ks::AbstractVector{<:AbstractString}, spec)
     if spec isa AbstractDict
         byname = Dict{String,Any}(String(k) => v for (k, v) in spec)
         return Dict{String,Any}(k => get(byname, k, identity) for k in ks)
@@ -83,6 +92,9 @@ function _jltransform_dict(py::Py, spec)
         return Dict{String,Any}(k => t for k in ks)
     end
 end
+
+# Convenience for callers that only have the Python object (e.g. `set_format!`).
+_jltransform_dict(py::Py, spec) = _jltransform_dict(_split_names(py), spec)
 
 # The julia transform to record for a split supplied as a `Dataset` (its own transform) or
 # a raw `Py` (none).
@@ -110,35 +122,61 @@ function _from_julia_splits(splits)
     return DatasetDict(py, spec)
 end
 
-function Base.getproperty(d::DatasetDict, s::Symbol)
-    if s in fieldnames(DatasetDict)
-        return getfield(d, s)
-    elseif s === :with_format
-        return format -> with_format(d, format)
+# Property names on a `DatasetDict` routed to this package's own methods instead of being
+# forwarded to Python: the format methods (which understand the `"julia"` pseudo-format) and
+# the julia-bridged `map`/`filter`, which both act per example over every split. `d.map(f)` is
+# `map(f, d)` and `d.filter(f)` is `filter(f, d)` (see below). To hand a raw Python callback,
+# use `d.py.map(...)` / `d.py.filter(...)`.
+function _method_override(d::DatasetDict, s::Symbol)
+    if s === :with_format
+        return (args...; kws...) -> with_format(d, args...; kws...)
+    elseif s === :set_format
+        return (args...; kws...) -> set_format!(d, args...; kws...)
+    elseif s === :reset_format
+        return (args...; kws...) -> reset_format!(d, args...; kws...)
+    elseif s === :map
+        return (f; kws...) -> map(f, d; kws...)
+    elseif s === :filter
+        return (f; kws...) -> filter(f, d; kws...)
     else
-        res = getproperty(getfield(d, :py), s)
-        if pycallable(res)
-            return CallableWrapper(res, getfield(d, :jltransform))
-        else
-            return res |> py2jl
-        end
+        return nothing
     end
 end
 
-Base.length(d::DatasetDict) = length(d.py)
+function Base.getproperty(d::DatasetDict, s::Symbol)
+    if s in fieldnames(DatasetDict)
+        return getfield(d, s)
+    end
+    # Route the format methods to this package's own versions (see `_method_override`) so the
+    # Python-style `d.with_format(...)`/`d.set_format(...)`/`d.reset_format()` calls handle the
+    # `"julia"` format; every other name forwards to the wrapped Python object.
+    override = _method_override(d, s)
+    override === nothing || return override
+    res = getproperty(getfield(d, :py), s)
+    if pycallable(res)
+        return CallableWrapper(res, getfield(d, :jltransform))
+    else
+        return res |> py2jl
+    end
+end
+
+# `length`/`keys`/`haskey` answer from the cached `splits` (no Python call): correct because
+# splits are immutable, and required so the REPL's async `d[<TAB>` completion — which calls
+# `keys`/`length` — does not invoke libpython off the main task and segfault.
+Base.length(d::DatasetDict) = length(getfield(d, :splits))
 
 function Base.getindex(d::DatasetDict, i::AbstractString)
     x = d.py[i]
     return Dataset(x, get(d.jltransform, i, identity))
 end
 
-Base.keys(d::DatasetDict) = String[pyconvert(String, k) for k in d.py.keys()]
+Base.keys(d::DatasetDict) = getfield(d, :splits)
 
 Base.values(d::DatasetDict) = Dataset[d[k] for k in keys(d)]
 
 Base.pairs(d::DatasetDict) = Pair{String,Dataset}[k => d[k] for k in keys(d)]
 
-Base.haskey(d::DatasetDict, k::AbstractString) = pyconvert(Bool, pyin(k, d.py))
+Base.haskey(d::DatasetDict, k::AbstractString) = k in getfield(d, :splits)
 
 Base.iterate(d::DatasetDict, state...) = iterate(pairs(d), state...)
 
@@ -150,11 +188,11 @@ function Base.get(d::DatasetDict, k::AbstractString, default)
     return pyis(x, pybuiltins.None) ? default : Dataset(x, get(d.jltransform, k, identity))
 end
 
-# The generic `AbstractDict` `merge`/`filter` build the result with `empty(d)`, which
-# returns a plain `Dict` and drops the wrapper. Override them to return a `DatasetDict`
-# backed by a fresh `datasets.DatasetDict`. Each surviving split keeps its own transform
-# (captured from the `Dataset` value), so per-split transforms are preserved; for `merge`,
-# later dicts win for both the data and the transform, mirroring `Base.merge`.
+# The generic `AbstractDict` `merge` builds the result with `empty(d)`, which returns a plain
+# `Dict` and drops the wrapper. Override it to return a `DatasetDict` backed by a fresh
+# `datasets.DatasetDict`. Each split keeps its own transform (captured from the `Dataset`
+# value); later dicts win for both the data and the transform, mirroring `Base.merge`.
+# (`filter` is not an `AbstractDict`-style override here — see `Base.filter` below.)
 _py(v::Dataset) = getfield(v, :py)
 _py(v::Py) = v
 
@@ -169,10 +207,48 @@ function _wrap_pairs(itr)
     return DatasetDict(py, spec)
 end
 
-Base.filter(f, d::DatasetDict) = _wrap_pairs(Iterators.filter(f, pairs(d)))
-
 function Base.merge(d::DatasetDict, others::AbstractDict...)
     return _wrap_pairs(Iterators.flatten((pairs(d), map(pairs, others)...)))
+end
+
+"""
+    map(f, d::DatasetDict; kws...)
+
+Apply `f` to every example of every split of `d` through `datasets`' `DatasetDict.map`,
+bridging Julia values on both sides just like the [`Dataset`](@ref) version: each example (or
+batch, with `batched=true`) is converted with [`py2jl`](@ref) before `f` sees it, and `f`'s
+return value is converted back with [`jl2py`](@ref). Keyword arguments are forwarded to the
+Python `map`, and each split keeps its own julia format/transform.
+
+`d.map(f; ...)` is equivalent to this `map(f, d; ...)`; use `d.py.map(...)` for a raw Python
+callback.
+
+See also [`filter`](@ref).
+"""
+function Base.map(f, d::DatasetDict; kws...)
+    g = x -> jl2py(f(py2jl(x)))
+    y = getfield(d, :py).map(g; kws...)
+    return DatasetDict(y, getfield(d, :jltransform))
+end
+
+"""
+    filter(f, d::DatasetDict; kws...)
+
+Filter every split of `d` by the Julia predicate `f`, applied per example (Python's
+`DatasetDict.filter`), bridging values with [`py2jl`](@ref)/[`jl2py`](@ref) exactly as
+[`map`](@ref) does. Returns a `DatasetDict` with the same splits, each keeping its own julia
+format/transform. `d.filter(f; ...)` is equivalent to this `filter(f, d; ...)`.
+
+!!! note
+    This deliberately overrides the generic `AbstractDict` `filter` (which would filter split
+    *entries*): `filter(f, ::DatasetDict)` filters *examples* within every split, to match
+    Python and the property-style `d.filter(f)`. To select splits, index the `DatasetDict` or
+    build a new one explicitly.
+"""
+function Base.filter(f, d::DatasetDict; kws...)
+    g = x -> jl2py(f(py2jl(x)))
+    y = getfield(d, :py).filter(g; kws...)
+    return DatasetDict(y, getfield(d, :jltransform))
 end
 
 function Base.deepcopy_internal(d::DatasetDict, stackdict::IdDict)

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -230,6 +230,54 @@ end
     @test ds.format["type"] === nothing
 end
 
+@testset "property-style format methods (python interface)" begin
+    # `ds.with_format`/`ds.set_format`/`ds.reset_format` route to this package's methods
+    # (not raw Python forwarding), so the `"julia"` pseudo-format works through them and
+    # stays consistent with the function forms.
+    ds = deepcopy(mnist)
+    set_format!(ds, nothing)
+    @test ds.format["type"] === nothing
+
+    ds.set_format("julia")                       # would error if forwarded to Python
+    @test ds.format["type"] == "numpy"           # julia format is numpy-backed
+    @test ds[1] isa Dict && ds[1]["label"] == 7
+
+    set_format!(ds, nothing)
+    ds.reset_format()                            # restores julia, not Python's strip-to-raw
+    @test ds.format["type"] == "numpy"
+    @test ds[1] isa Dict
+
+    dsj = ds.with_format("julia")                # non-mutating; returns a wrapped Dataset
+    @test dsj isa Dataset
+    @test dsj[1]["label"] == 7
+end
+
+@testset "Dataset.from_dict (python classmethod name)" begin
+    # `Dataset.from_dict` mirrors `datasets.Dataset.from_dict` via type-level getproperty,
+    # matching the `Dataset(data)` constructor (orientation-aware columns, "julia" format).
+    ds = Dataset.from_dict(Dict("label" => [5, 0, 4]))
+    @test ds isa Dataset
+    @test ds.format["type"] == "numpy"           # default julia format, like the constructor
+    @test ds[1] == Dict("label" => 5)
+    @test ds[1:3]["label"] == [5, 0, 4]
+
+    # NamedTuple input, and parity with the `Dataset(data)` constructor
+    @test Dataset.from_dict((; label = [5, 0, 4]))[1:3]["label"] == Dataset((; label = [5, 0, 4]))[1:3]["label"]
+
+    # N-D array column uses the same last-axis stacking as the constructor
+    m = [1 2 3; 4 5 6]
+    a = Dataset.from_dict((; x = m))
+    @test a[1]["x"] == [1, 4]
+    @test a[1:3]["x"] == m
+
+    # a raw Python mapping is accepted too (converted via jl2py)
+    c = Dataset.from_dict(pydict(Dict("label" => pylist([10, 20]))))
+    @test c[2]["label"] == 20
+
+    # type introspection is unaffected by the type-level getproperty overload
+    @test fieldnames(Dataset) == (:py, :jltransform)
+end
+
 @testset "jltransform always acts on batches" begin
     ds = with_jltransform(mnist) do x
         x = py2jl(x)
@@ -290,4 +338,14 @@ end
     ds5 = filter(x -> x["label"] .< 3, dsj; batched=true)
     @test ds5[1] isa Dict{String, Int64}
     @test sort(ds5[1:length(ds5)]["label"]) == [0, 1, 2]
+
+    # property-style `ds.map` / `ds.filter` route to the julia-bridged versions above
+    # (python interface), i.e. `ds.map(f)` == `map(f, ds)` — the callback still sees Julia
+    # values. A raw Python callback would go through `ds.py.map(...)` instead.
+    dm = dsj.map(x -> Dict("label" => x["label"] .+ 100); batched=true)
+    @test dm isa Dataset
+    @test dm[1:6]["label"] == [105, 100, 104, 103, 102, 101]
+    df = dsj.filter(x -> x["label"] > 2)
+    @test df isa Dataset
+    @test sort(df[1:length(df)]["label"]) == [3, 4, 5]
 end

--- a/test/datasetdict.jl
+++ b/test/datasetdict.jl
@@ -153,12 +153,22 @@ end
     @test mnist["test"].format["type"] == "numpy"           # original untouched
 end
 
-@testset "merge / filter preserve the wrapper type" begin
-    # `merge`/`filter` must return a `DatasetDict`, not a plain `Dict{String,Dataset}`.
-    f = filter(p -> p.first == "train", mnist)
-    @test f isa DatasetDict
-    @test collect(keys(f)) == ["train"]
+@testset "property-style format methods (python interface)" begin
+    # `d.set_format`/`d.reset_format`/`d.with_format` route to this package's methods, so the
+    # `"julia"` pseudo-format works across all splits through the Python-style calls.
+    d = set_format!(copy(mnist), nothing)
+    @test d["test"].format["type"] === nothing
+    d.set_format("julia")                                   # would error if forwarded to Python
+    @test d["test"].format["type"] == "numpy"
+    @test d["test"][1] isa Dict
+    set_format!(d, nothing)
+    d.reset_format()
+    @test d["test"].format["type"] == "numpy"
+    @test d.with_format("julia") isa DatasetDict
+end
 
+@testset "merge preserves the wrapper type" begin
+    # `merge` must return a `DatasetDict`, not a plain `Dict{String,Dataset}`.
     extra = load_dataset("ylecun/mnist")["test"]   # a lone `Dataset`
     m = merge(mnist, Dict("extra" => extra))
     @test m isa DatasetDict
@@ -168,13 +178,51 @@ end
     m2 = merge(mnist, Dict("train" => extra))
     @test m2 isa DatasetDict
     @test length(m2["train"]) == length(extra)
+end
 
-    # the `jltransform` of the first argument is carried over
-    dj = with_format(mnist, "julia")
-    fj = filter(p -> p.first == "test", dj)
-    @test fj isa DatasetDict
-    @test fj["test"][1] isa Dict
-    @test fj["test"][1]["label"] isa Int
+@testset "julia-friendly map / filter (DatasetDict)" begin
+    dd = DatasetDict("train" => Dataset((; label=[5, 0, 4, 3])),
+                     "test"  => Dataset((; label=[1, 2])))
+
+    # `map(f, dd)` and `dd.map(f)` both bridge Julia values, per-example over every split
+    dm = map(x -> Dict("label" => x["label"] + 10), dd)
+    @test dm isa DatasetDict
+    @test Set(keys(dm)) == Set(["train", "test"])
+    @test dm["train"][1:4]["label"] == [15, 10, 14, 13]
+    @test dm["test"][1:2]["label"] == [11, 12]
+    @test dd.map(x -> Dict("label" => x["label"] + 10))["train"][1:4]["label"] == [15, 10, 14, 13]
+
+    # `filter(f, dd)` and `dd.filter(f)` both filter EXAMPLES within every split (python
+    # `DatasetDict.filter`) — the function form no longer filters splits.
+    df = filter(x -> x["label"] > 2, dd)
+    @test df isa DatasetDict
+    @test Set(keys(df)) == Set(["train", "test"])       # both splits kept
+    @test sort(df["train"][1:length(df["train"])]["label"]) == [3, 4, 5]
+    @test length(df["test"]) == 0                        # none > 2
+    # the property form is equivalent
+    dfp = dd.filter(x -> x["label"] > 2)
+    @test sort(dfp["train"][1:length(dfp["train"])]["label"]) == [3, 4, 5]
+    @test length(dfp["test"]) == 0
+
+    # batched map keyword is forwarded
+    db = dd.map(x -> Dict("label" => x["label"] .* 2); batched=true)
+    @test db["train"][1:4]["label"] == [10, 0, 8, 6]
+end
+
+@testset "keys/length are cached and stay correct" begin
+    # `keys`/`length`/`haskey` are served from the cached split names (no Python call), which
+    # is what makes REPL `d[<TAB>` completion safe. Guard that the cache is correct and stays
+    # in sync with the underlying python object across (re)construction.
+    dd = DatasetDict("a" => Dataset((; x=[1, 2])), "b" => Dataset((; x=[3])))
+    @test keys(dd) == ["a", "b"]                 # cached, ordered
+    @test length(dd) == 2
+    @test haskey(dd, "a") && !haskey(dd, "z")
+    @test keys(dd) == [pyconvert(String, k) for k in dd.py.keys()]   # matches python truth
+
+    # reconstruction via a forwarded/bridged method keeps the cache correct
+    dm = map(x -> Dict("x" => x["x"] .+ 1), dd)
+    @test keys(dm) == ["a", "b"] && length(dm) == 2
+    @test keys(deepcopy(dd)) == ["a", "b"]
 end
 
 @testset "set_jltransform!" begin


### PR DESCRIPTION
## Summary

Makes the wrapper track the Python `datasets` API more closely while staying idiomatic Julia, and fixes a REPL segfault.

### Python-style interface (via `getproperty`)
- **Format methods** `ds.set_format(...)` / `ds.reset_format()` / `ds.with_format(...)` (and the `DatasetDict` equivalents) now route to this package's own methods, so the `"julia"` pseudo-format works through the dot-calls. Previously `ds.set_format("julia")` **errored** (it forwarded to Python, which has no `"julia"` format) and `ds.reset_format()` silently diverged from `reset_format!`.
- **`Dataset.from_dict(...)`** — exposed under its Python classmethod name via type-level `getproperty`, using the same orientation-aware column handling as the `Dataset(data)` constructor and defaulting to the `"julia"` format.
- **`map`/`filter` bridge Julia values.** `ds.map(f)` / `ds.filter(f)` are now equivalent to `map(f, ds)` / `filter(f, ds)` (the callback sees Julia values via `py2jl`/`jl2py`; the raw-Python escape hatch is `ds.py.map(...)`). Added `map(f, ::DatasetDict)`, and **`filter(f, dd)` now filters _examples_** across every split like `dd.filter(f)`.

### Crash fix
Typing `d[<TAB>` on a `DatasetDict` segfaulted: REPL tab-completion calls `keys`/`length` on its async completion task, and our `keys` called into `libpython` off the main task (`_PyObject_Malloc` → `PyUnicode_New`). `DatasetDict` now **caches its ordered split names** at construction, so `keys`/`length`/`haskey` are Python-free — fixing the crash, and a small perf win since they no longer round-trip on every call/iteration.

### Notable decision
`filter(f, ::DatasetDict)` deliberately **overrides the `AbstractDict` split-filter** to match Python's per-example `DatasetDict.filter`. Selecting splits is no longer done via `filter` (documented in the docstring).

## Tests
Full suite green: transforms 31, dataset 146, datasetdict 98, larger 19. Docs (guide + api) updated.

## Residual follow-ups (out of scope here)
Other off-main-task Python-call risks remain, inherent to the PythonCall bridge: `show(::Dataset/::DatasetDict)` calls Python `__repr__`, so IDE/notebook frontends that render on a background task could crash; multithreaded Python access (e.g. a threaded `DataLoader` pulling `ds[i]`) is unsafe under the GIL. An optional `Column` length cache (mirroring this fix) would harden collection introspection further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)