### PR TITLE
Add Tables.jl construction path: Dataset(table)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HuggingFaceDatasets"
 uuid = "d94b9a45-fdf5-4270-b024-5cbb9ef7117d"
-authors = ["Carlo Lucibello"]
 version = "0.4.0"
+authors = ["Carlo Lucibello"]
 
 [workspace]
 projects = ["test", "docs"]
@@ -12,6 +12,7 @@ DLPack = "53c2dc0f-f7d5-43fd-8906-6c0220547083"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 CondaPkg = "0.2"
@@ -19,5 +20,5 @@ DLPack = "0.3"
 ImageCore = "0.9, 0.10"
 MLUtils = "0.4.1"
 PythonCall = "0.9"
+Tables = "1"
 julia = "1.10"
-

--- a/src/HuggingFaceDatasets.jl
+++ b/src/HuggingFaceDatasets.jl
@@ -4,7 +4,8 @@ using PythonCall
 using MLUtils: getobs, numobs
 import MLUtils
 using DLPack: DLPack
-using ImageCore
+using ImageCore: colorview, RGB, Gray, N0f8
+using Tables: Tables
 
 const datasets = PythonCall.pynew()
 const PIL = PythonCall.pynew()

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -124,6 +124,45 @@ Dataset(d::AbstractDict; jltransform = nothing) =
 Dataset(nt::NamedTuple; jltransform = nothing) =
     _from_julia_data(_from_dict_pydict(nt), jltransform)
 
+"""
+    Dataset(table; jltransform = nothing)
+
+Build a `Dataset` from any [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible
+source — a `DataFrame`, `CSV.File`, row table, and so on. The table is materialized to a
+column `NamedTuple` with `Tables.columntable` and then handed to the `Dataset(::NamedTuple)`
+column path, so column-name order, scalar columns, and the default `"julia"` format all
+behave exactly as for in-memory columns. This avoids the pandas dependency that
+`datasets.Dataset.from_pandas` would pull in and covers far more sources.
+
+See also [`Dataset(::AbstractDict)`](@ref) and [`with_format`](@ref).
+
+# Examples
+
+```julia
+julia> using DataFrames
+
+julia> df = DataFrame(label = [5, 0, 4], text = ["a", "b", "c"]);
+
+julia> ds = Dataset(df)
+Dataset({
+    features: ['label', 'text'],
+    num_rows: 3
+})
+
+julia> ds[1:3]["label"]
+3-element Vector{Int64}:
+ 5
+ 0
+ 4
+```
+"""
+function Dataset(table; jltransform = nothing)
+    Tables.istable(table) || throw(ArgumentError(
+        "`Dataset(x)` expects a Tables.jl-compatible table, an `AbstractDict`, or a " *
+        "`NamedTuple` of columns; got a $(typeof(table)), which is not a table"))
+    return Dataset(Tables.columntable(table); jltransform)
+end
+
 # Wrap a freshly built `datasets.Dataset` from Julia data. With no explicit `jltransform`
 # the dataset defaults to the `"julia"` format; passing a transform installs it instead
 # (leaving the Python format untouched, i.e. observations arrive as raw Python batches).

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -85,6 +85,26 @@ end
     @test_throws ArgumentError Dataset(Dict("x" => 5))
 end
 
+@testset "construct from a Tables.jl source" begin
+    # A row table (vector of NamedTuples) is Tables.jl-compatible and lands on the generic
+    # `Dataset(table)` method; it must match the equivalent column construction.
+    rt = [(label = 5, text = "a"), (label = 0, text = "b"), (label = 4, text = "c")]
+    ds = Dataset(rt)
+    @test length(ds) == 3
+    @test ds.column_names == ["label", "text"]
+    @test ds[1:3]["label"] == [5, 0, 4]
+    @test ds[1:3]["text"] == ["a", "b", "c"]
+    @test ds[1:3]["label"] == Dataset((label = [5, 0, 4], text = ["a", "b", "c"]))[1:3]["label"]
+
+    # a custom `jltransform` is forwarded through the table path
+    ds = Dataset(rt; jltransform = py2jl)
+    @test ds.format["type"] === nothing
+    @test ds[1]["label"] == 5
+
+    # a non-table scalar is rejected with a clear error
+    @test_throws ArgumentError Dataset(5)
+end
+
 @testset "keyword arguments are forwarded to python methods" begin
     # `train_test_split` requires the `test_size` keyword: regression test for the
     # kwargs-forwarding bug where keywords were splatted as positional arguments.


### PR DESCRIPTION
## Summary

Closes the remaining gap in **review item 1** — an idiomatic Tables.jl ingestion path.

- Adds a `Dataset(table; jltransform = nothing)` constructor for any
  [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible source (a `DataFrame`,
  `CSV.File`, row table, ...). It validates with `Tables.istable`, materializes with
  `Tables.columntable`, and reuses the existing `Dataset(::NamedTuple)` column path, so
  column-name order, scalar columns, and the default `"julia"` format all behave exactly
  as for in-memory columns.
- This avoids the pandas dependency that `datasets.Dataset.from_pandas` would pull in and
  covers far more sources.
- The more specific `Dataset(::Py)` / `Dataset(::AbstractDict)` / `Dataset(::NamedTuple)`
  methods still take precedence, so only genuine tables (and mistaken non-tables, which
  get a clear `ArgumentError`) land on the generic method.
- Adds `Tables` as a light direct dependency (`compat = "1"`).

Also tightens the `ImageCore` import to the four symbols actually used
(`colorview`, `RGB`, `Gray`, `N0f8`) instead of `using ImageCore`.

## Tests

New `"construct from a Tables.jl source"` testset in `test/dataset.jl`: a row table
matches the equivalent column construction, `jltransform` forwarding works, and a
non-table is rejected. Passes 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)